### PR TITLE
Fix: Rename package and repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ require 'vendor/autoload.php';
 
 use Github\Client;
 use Github\HttpClient\CachedHttpClient;
-use Localheinz\ChangeLog\Entity;
-use Localheinz\ChangeLog\Repository;
+use Localheinz\GitHub\ChangeLog\Entity;
+use Localheinz\GitHub\ChangeLog\Repository;
 
 $client = new Client(new CachedHttpClient());
 $client->authenticate(

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "localheinz/change-log",
+    "name": "localheinz/github-changelog",
     "description": "A script that generates a change log based on specified references.",
     "authors": [
         {
@@ -20,12 +20,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Localheinz\\ChangeLog\\": "src"
+            "Localheinz\\GitHub\\ChangeLog\\": "src"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Localheinz\\ChangeLog\\Test\\": "tests"
+            "Localheinz\\GitHub\\ChangeLog\\Test\\": "tests"
         }
     }
 }

--- a/src/Entity/Commit.php
+++ b/src/Entity/Commit.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Localheinz\ChangeLog\Entity;
+namespace Localheinz\GitHub\ChangeLog\Entity;
 
 class Commit
 {

--- a/src/Entity/PullRequest.php
+++ b/src/Entity/PullRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Localheinz\ChangeLog\Entity;
+namespace Localheinz\GitHub\ChangeLog\Entity;
 
 class PullRequest
 {

--- a/src/Provider/PullRequest.php
+++ b/src/Provider/PullRequest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Localheinz\ChangeLog\Provider;
+namespace Localheinz\GitHub\ChangeLog\Provider;
 
-use Localheinz\ChangeLog\Entity;
-use Localheinz\ChangeLog\Repository;
+use Localheinz\GitHub\ChangeLog\Entity;
+use Localheinz\GitHub\ChangeLog\Repository;
 
 class PullRequest
 {

--- a/src/Repository/Commit.php
+++ b/src/Repository/Commit.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Localheinz\ChangeLog\Repository;
+namespace Localheinz\GitHub\ChangeLog\Repository;
 
 use Github\Api;
-use Localheinz\ChangeLog\Entity;
+use Localheinz\GitHub\ChangeLog\Entity;
 
 class Commit
 {

--- a/src/Repository/PullRequest.php
+++ b/src/Repository/PullRequest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Localheinz\ChangeLog\Repository;
+namespace Localheinz\GitHub\ChangeLog\Repository;
 
 use Github\Api;
-use Localheinz\ChangeLog\Entity;
+use Localheinz\GitHub\ChangeLog\Entity;
 
 class PullRequest
 {

--- a/tests/Entity/CommitTest.php
+++ b/tests/Entity/CommitTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Localheinz\ChangeLog\Test\Entity;
+namespace Localheinz\GitHub\ChangeLog\Test\Entity;
 
-use Localheinz\ChangeLog\Entity;
+use Localheinz\GitHub\ChangeLog\Entity;
 use PHPUnit_Framework_TestCase;
 
 class CommitTest extends PHPUnit_Framework_TestCase

--- a/tests/Entity/PullRequestTest.php
+++ b/tests/Entity/PullRequestTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Localheinz\ChangeLog\Test\Entity;
+namespace Localheinz\GitHub\ChangeLog\Test\Entity;
 
-use Localheinz\ChangeLog\Entity;
+use Localheinz\GitHub\ChangeLog\Entity;
 use PHPUnit_Framework_TestCase;
 
 class PullRequestTest extends PHPUnit_Framework_TestCase

--- a/tests/Repository/CommitTest.php
+++ b/tests/Repository/CommitTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Localheinz\ChangeLog\Test\Repository;
+namespace Localheinz\GitHub\ChangeLog\Test\Repository;
 
 use Faker;
 use Github\Api;
-use Localheinz\ChangeLog\Entity;
-use Localheinz\ChangeLog\Repository;
-use Localheinz\ChangeLog\Test\Util\FakerTrait;
+use Localheinz\GitHub\ChangeLog\Entity;
+use Localheinz\GitHub\ChangeLog\Repository;
+use Localheinz\GitHub\ChangeLog\Test\Util\FakerTrait;
 use PHPUnit_Framework_MockObject_MockObject;
 use PHPUnit_Framework_TestCase;
 use stdClass;

--- a/tests/Repository/PullRequestTest.php
+++ b/tests/Repository/PullRequestTest.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace Localheinz\ChangeLog\Test\Repository;
+namespace Localheinz\GitHub\ChangeLog\Test\Repository;
 
 use Faker;
 use Github\Api;
-use Localheinz\ChangeLog\Entity;
-use Localheinz\ChangeLog\Repository;
-use Localheinz\ChangeLog\Test\Util\FakerTrait;
+use Localheinz\GitHub\ChangeLog\Entity;
+use Localheinz\GitHub\ChangeLog\Repository;
+use Localheinz\GitHub\ChangeLog\Test\Util\FakerTrait;
 use PHPUnit_Framework_MockObject_MockObject;
 use PHPUnit_Framework_TestCase;
 use stdClass;

--- a/tests/Util/FakerTrait.php
+++ b/tests/Util/FakerTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Localheinz\ChangeLog\Test\Util;
+namespace Localheinz\GitHub\ChangeLog\Test\Util;
 
 use Faker;
 


### PR DESCRIPTION
This PR

* [x] renames the namespace from `Localheinz\ChangeLog` to `Localheinz\GitHub\ChangeLog`
* [x] renames the package from `localheinz/change-log` to `localheinz/github-changelog`