### PR TITLE
Fix: all() always returns an array

### DIFF
--- a/src/Repository/Commit.php
+++ b/src/Repository/Commit.php
@@ -57,10 +57,6 @@ class Commit
             'sha' => $end->sha(),
         ]);
 
-        if (!is_array($commits)) {
-            return [];
-        }
-
         $range = [];
 
         $tail = null;


### PR DESCRIPTION
This PR

* [x] removes code which will never get executed