### PR TITLE
Fix: Assert exit code is set to 0

### DIFF
--- a/src/Console/ChangeLogCommand.php
+++ b/src/Console/ChangeLogCommand.php
@@ -83,6 +83,7 @@ class ChangeLogCommand extends Command
     /**
      * @param Input\InputInterface $input
      * @param Output\OutputInterface $output
+     * @return int
      */
     protected function execute(Input\InputInterface $input, Output\OutputInterface $output)
     {
@@ -120,6 +121,8 @@ class ChangeLogCommand extends Command
 
             $output->writeln($message);
         });
+
+        return 0;
     }
 
     /**

--- a/tests/Console/ChangeLogCommandTest.php
+++ b/tests/Console/ChangeLogCommandTest.php
@@ -330,13 +330,15 @@ class ChangeLogCommandTest extends PHPUnit_Framework_TestCase
             'template' => $template,
         ];
 
-        $this->command->run(
+        $exitCode = $this->command->run(
             $this->input(
                 $arguments,
                 $options
             ),
             $this->output($expectedMessages)
         );
+
+        $this->assertSame(0, $exitCode);
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] updates `Console\ChangeLogCommand` to return `0`