### PR TITLE
Fix: Request 250 instead of 30 commits

### DIFF
--- a/src/Repository/Commit.php
+++ b/src/Repository/Commit.php
@@ -119,6 +119,10 @@ class Commit
      */
     public function all($vendor, $package, array $params = [])
     {
+        if (!array_key_exists('per_page', $params)) {
+            $params['per_page'] = 250;
+        }
+
         $response = $this->api->all(
             $vendor,
             $package,


### PR DESCRIPTION
This PR

* [x] sets the `per_page` parameter to `250` when fetching commits, effectively cutting down on requests (default is `30`, however, API would return more, see https://developer.github.com/v3/repos/commits/#working-with-large-comparisons)