### PR TITLE
Fix: CHANGELOG.md and Make file excluded from dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,5 @@
 /.travis.yml export-ignore
 /phpunit.xml export-ignore
 /README.md export-ignore
+/CONTRIBUTING.md export-ignore
+/Makefile


### PR DESCRIPTION
These two files show up in the [release downloads](https://github.com/localheinz/github-changelog/releases), so I excluded them.