### PR TITLE
Fix: Configure Code Climate via file

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,2 @@
+languages:
+  PHP: true


### PR DESCRIPTION
This PR

* [x] adds a `.codeclimate.yml` configuration, since web-based configuration has been deprecated