### PR TITLE
Fix: Rename repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ $client->authenticate(
     Client::AUTH_HTTP_TOKEN
 );
 
-$repository = new Repository\PullRequest(
+$repository = new Repository\PullRequestRepository(
     $client->pullRequests(),
-    new Repository\Commit($client->repositories()->commits())
+    new Repository\CommitRepository($client->repositories()->commits())
 );
 
 $pullRequests = $repository->items(

--- a/src/Console/PullRequestCommand.php
+++ b/src/Console/PullRequestCommand.php
@@ -20,7 +20,7 @@ class PullRequestCommand extends Command
     private $client;
 
     /**
-     * @var Repository\PullRequest
+     * @var Repository\PullRequestRepository
      */
     private $pullRequestRepository;
 
@@ -33,9 +33,9 @@ class PullRequestCommand extends Command
     }
 
     /**
-     * @param Repository\PullRequest $pullRequestRepository
+     * @param Repository\PullRequestRepository $pullRequestRepository
      */
-    public function setPullRequestRepository(Repository\PullRequest $pullRequestRepository)
+    public function setPullRequestRepository(Repository\PullRequestRepository $pullRequestRepository)
     {
         $this->pullRequestRepository = $pullRequestRepository;
     }
@@ -148,7 +148,7 @@ class PullRequestCommand extends Command
     }
 
     /**
-     * @return Repository\PullRequest
+     * @return Repository\PullRequestRepository
      */
     private function pullRequestRepository()
     {
@@ -158,9 +158,9 @@ class PullRequestCommand extends Command
             $pullRequestApi = new Api\PullRequest($client);
             $commitApi = new Api\Repository\Commits($client);
 
-            $this->pullRequestRepository = new Repository\PullRequest(
+            $this->pullRequestRepository = new Repository\PullRequestRepository(
                 $pullRequestApi,
-                new Repository\Commit($commitApi)
+                new Repository\CommitRepository($commitApi)
             );
         }
 

--- a/src/Repository/CommitRepository.php
+++ b/src/Repository/CommitRepository.php
@@ -5,7 +5,7 @@ namespace Localheinz\GitHub\ChangeLog\Repository;
 use Github\Api;
 use Localheinz\GitHub\ChangeLog\Entity;
 
-class Commit
+class CommitRepository
 {
     /**
      * @var Api\Repository\Commits

--- a/src/Repository/PullRequestRepository.php
+++ b/src/Repository/PullRequestRepository.php
@@ -5,7 +5,7 @@ namespace Localheinz\GitHub\ChangeLog\Repository;
 use Github\Api;
 use Localheinz\GitHub\ChangeLog\Entity;
 
-class PullRequest
+class PullRequestRepository
 {
     /**
      * @var Api\PullRequest
@@ -13,14 +13,14 @@ class PullRequest
     private $api;
 
     /**
-     * @var Commit
+     * @var CommitRepository
      */
     private $commitRepository;
 
     /**
      * @param Api\PullRequest $api
      */
-    public function __construct(Api\PullRequest $api, Commit $commitRepository)
+    public function __construct(Api\PullRequest $api, CommitRepository $commitRepository)
     {
         $this->api = $api;
         $this->commitRepository = $commitRepository;

--- a/tests/Console/PullRequestCommandTest.php
+++ b/tests/Console/PullRequestCommandTest.php
@@ -256,7 +256,7 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
 
         $pullRequestRepository = $property->getValue($this->command);
 
-        $this->assertInstanceOf(Repository\PullRequest::class, $pullRequestRepository);
+        $this->assertInstanceOf(Repository\PullRequestRepository::class, $pullRequestRepository);
     }
 
     public function testExecuteDelegatesToPullRequestRepository()
@@ -398,11 +398,11 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return PHPUnit_Framework_MockObject_MockObject|Repository\PullRequest
+     * @return PHPUnit_Framework_MockObject_MockObject|Repository\PullRequestRepository
      */
     private function pullRequestRepository()
     {
-        return $this->getMockBuilder(Repository\PullRequest::class)
+        return $this->getMockBuilder(Repository\PullRequestRepository::class)
             ->disableOriginalConstructor()
             ->getMock()
         ;

--- a/tests/Repository/CommitRepositoryTest.php
+++ b/tests/Repository/CommitRepositoryTest.php
@@ -11,7 +11,7 @@ use PHPUnit_Framework_MockObject_MockObject;
 use PHPUnit_Framework_TestCase;
 use stdClass;
 
-class CommitTest extends PHPUnit_Framework_TestCase
+class CommitRepositoryTest extends PHPUnit_Framework_TestCase
 {
     use FakerTrait;
 
@@ -36,7 +36,7 @@ class CommitTest extends PHPUnit_Framework_TestCase
             ->willReturn($this->response($expectedItem))
         ;
 
-        $commitRepository = new Repository\Commit($api);
+        $commitRepository = new Repository\CommitRepository($api);
 
         $commit = $commitRepository->show(
             $vendor,
@@ -69,7 +69,7 @@ class CommitTest extends PHPUnit_Framework_TestCase
             ->willReturn('failure')
         ;
 
-        $commitRepository = new Repository\Commit($api);
+        $commitRepository = new Repository\CommitRepository($api);
 
         $commit = $commitRepository->show(
             $vendor,
@@ -99,7 +99,7 @@ class CommitTest extends PHPUnit_Framework_TestCase
             ->willReturn('snafu')
         ;
 
-        $repository = new Repository\Commit($api);
+        $repository = new Repository\CommitRepository($api);
 
         $commits = $repository->all(
             $vendor,
@@ -133,7 +133,7 @@ class CommitTest extends PHPUnit_Framework_TestCase
             ->willReturn($this->responseFromItems($expectedItems))
         ;
 
-        $repository = new Repository\Commit($api);
+        $repository = new Repository\CommitRepository($api);
 
         $repository->all(
             $vendor,
@@ -166,7 +166,7 @@ class CommitTest extends PHPUnit_Framework_TestCase
             ->willReturn($this->responseFromItems($expectedItems))
         ;
 
-        $repository = new Repository\Commit($api);
+        $repository = new Repository\CommitRepository($api);
 
         $repository->all(
             $vendor,
@@ -199,7 +199,7 @@ class CommitTest extends PHPUnit_Framework_TestCase
             ->willReturn($this->responseFromItems($expectedItems))
         ;
 
-        $repository = new Repository\Commit($api);
+        $repository = new Repository\CommitRepository($api);
 
         $commits = $repository->all(
             $vendor,
@@ -238,7 +238,7 @@ class CommitTest extends PHPUnit_Framework_TestCase
             ->method($this->anything())
         ;
 
-        $repository = new Repository\Commit($api);
+        $repository = new Repository\CommitRepository($api);
 
         $commits = $repository->items(
             $vendor,
@@ -275,7 +275,7 @@ class CommitTest extends PHPUnit_Framework_TestCase
             ->method('all')
         ;
 
-        $repository = new Repository\Commit($api);
+        $repository = new Repository\CommitRepository($api);
 
         $commits = $repository->items(
             $vendor,
@@ -323,7 +323,7 @@ class CommitTest extends PHPUnit_Framework_TestCase
             ->method('all')
         ;
 
-        $repository = new Repository\Commit($api);
+        $repository = new Repository\CommitRepository($api);
 
         $commits = $repository->items(
             $vendor,
@@ -380,7 +380,7 @@ class CommitTest extends PHPUnit_Framework_TestCase
             )
         ;
 
-        $repository = new Repository\Commit($api);
+        $repository = new Repository\CommitRepository($api);
 
         $repository->items(
             $vendor,
@@ -458,7 +458,7 @@ class CommitTest extends PHPUnit_Framework_TestCase
             ->willReturn($this->responseFromItems($segment))
         ;
 
-        $repository = new Repository\Commit($api);
+        $repository = new Repository\CommitRepository($api);
 
         $commits = $repository->items(
             $vendor,
@@ -573,7 +573,7 @@ class CommitTest extends PHPUnit_Framework_TestCase
             ->willReturn($this->responseFromItems($secondSegment))
         ;
 
-        $repository = new Repository\Commit($api);
+        $repository = new Repository\CommitRepository($api);
 
         $commits = $repository->items(
             $vendor,

--- a/tests/Repository/PullRequestRepositoryTest.php
+++ b/tests/Repository/PullRequestRepositoryTest.php
@@ -11,7 +11,7 @@ use PHPUnit_Framework_MockObject_MockObject;
 use PHPUnit_Framework_TestCase;
 use stdClass;
 
-class PullRequestTest extends PHPUnit_Framework_TestCase
+class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
 {
     use FakerTrait;
 
@@ -35,7 +35,7 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
             ->willReturn($this->response($expectedItem))
         ;
 
-        $pullRequestRepository = new Repository\PullRequest(
+        $pullRequestRepository = new Repository\PullRequestRepository(
             $api,
             $this->commitRepository()
         );
@@ -72,7 +72,7 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
             ->willReturn('snafu')
         ;
 
-        $pullRequestRepository = new Repository\PullRequest(
+        $pullRequestRepository = new Repository\PullRequestRepository(
             $api,
             $this->commitRepository()
         );
@@ -107,7 +107,7 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
             ->willReturn([])
         ;
 
-        $repository = new Repository\PullRequest(
+        $repository = new Repository\PullRequestRepository(
             $this->pullRequestApi(),
             $commitRepository
         );
@@ -150,7 +150,7 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
             ])
         ;
 
-        $repository = new Repository\PullRequest(
+        $repository = new Repository\PullRequestRepository(
             $this->pullRequestApi(),
             $commitRepository
         );
@@ -211,7 +211,7 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
             ->willReturn($this->response($expectedItem))
         ;
 
-        $repository = new Repository\PullRequest(
+        $repository = new Repository\PullRequestRepository(
             $api,
             $commitRepository
         );
@@ -281,7 +281,7 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
             ->willReturn(null)
         ;
 
-        $repository = new Repository\PullRequest(
+        $repository = new Repository\PullRequestRepository(
             $api,
             $commitRepository
         );
@@ -312,7 +312,7 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
      */
     private function commitRepository()
     {
-        return $this->getMockBuilder(Repository\Commit::class)
+        return $this->getMockBuilder(Repository\CommitRepository::class)
             ->disableOriginalConstructor()
             ->getMock()
         ;


### PR DESCRIPTION
This PR

* [x] renames repositories, appending `Repository`