### PR TITLE
Fix: Undefined methods, type incompatibility

### DIFF
--- a/tests/Console/PullRequestCommandTest.php
+++ b/tests/Console/PullRequestCommandTest.php
@@ -476,7 +476,7 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
     private function pullRequest()
     {
         return new Entity\PullRequest(
-            $this->faker()->unique()->randomNumber,
+            $this->faker()->unique()->randomNumber(),
             $this->faker()->unique()->sentence()
         );
     }

--- a/tests/Console/PullRequestCommandTest.php
+++ b/tests/Console/PullRequestCommandTest.php
@@ -159,6 +159,7 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
 
     public function testCanSetClient()
     {
+        /* @var Client $client */
         $client = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
             ->getMock()

--- a/tests/Repository/CommitRepositoryTest.php
+++ b/tests/Repository/CommitRepositoryTest.php
@@ -596,7 +596,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return PHPUnit_Framework_MockObject_MockObject
+     * @return PHPUnit_Framework_MockObject_MockObject|Api\Repository\Commits
      */
     private function commitApi()
     {

--- a/tests/Repository/PullRequestRepositoryTest.php
+++ b/tests/Repository/PullRequestRepositoryTest.php
@@ -57,7 +57,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
         $vendor = 'foo';
         $package = 'bar';
 
-        $id = $this->faker()->unique()->randomNumber;
+        $id = $this->faker()->unique()->randomNumber();
 
         $api = $this->pullRequestApi();
 
@@ -325,7 +325,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
     {
         $item = new stdClass();
 
-        $item->id = $this->faker()->unique()->randomNumber;
+        $item->id = $this->faker()->unique()->randomNumber();
         $item->title = $this->faker()->unique()->sentence();
 
         return $item;

--- a/tests/Repository/PullRequestRepositoryTest.php
+++ b/tests/Repository/PullRequestRepositoryTest.php
@@ -297,7 +297,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return PHPUnit_Framework_MockObject_MockObject
+     * @return PHPUnit_Framework_MockObject_MockObject|Api\PullRequest
      */
     private function pullRequestApi()
     {
@@ -308,7 +308,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return PHPUnit_Framework_MockObject_MockObject
+     * @return PHPUnit_Framework_MockObject_MockObject|Repository\CommitRepository
      */
     private function commitRepository()
     {


### PR DESCRIPTION
This PR

* [x] uses annotated methods of `Faker\Generator`
* [x] updates docblocks, adds inline comments