### PR TITLE
Fix: Move github-changelog to bin directory

### DIFF
--- a/bin/github-changelog
+++ b/bin/github-changelog
@@ -2,8 +2,8 @@
 <?php
 
 $autoloaders = [
-    __DIR__ . '/../../../vendor/autoload.php',
-    __DIR__ . '/vendor/autoload.php',
+    __DIR__ . '/../../../../vendor/autoload.php',
+    __DIR__ . '/../vendor/autoload.php',
 ];
 
 foreach ($autoloaders as $autoloader) {

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,6 @@
         }
     },
     "bin": [
-        "github-changelog"
+        "bin/github-changelog"
     ]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "bb506bc71b3df98aa156471e28fa6ae1",
+    "hash": "68e88cdc3f476f422d07055cad52a723",
     "packages": [
         {
             "name": "guzzle/guzzle",


### PR DESCRIPTION
This PR

* [x] moves `github-changelog` to `bin` directory