### PR TITLE
Enhancement: Make end reference an optional argument

### DIFF
--- a/src/Console/PullRequestCommand.php
+++ b/src/Console/PullRequestCommand.php
@@ -58,7 +58,7 @@ class PullRequestCommand extends Command
             )
             ->addArgument(
                 'end-reference',
-                Input\InputArgument::REQUIRED,
+                Input\InputArgument::OPTIONAL,
                 'The end reference, e.g. "1.1.0"'
             )
             ->addOption(

--- a/src/Repository/CommitRepository.php
+++ b/src/Repository/CommitRepository.php
@@ -21,10 +21,10 @@ class CommitRepository
      * @param string $owner
      * @param string $repository
      * @param string $startReference
-     * @param string $endReference
+     * @param string|null $endReference
      * @return Entity\Commit[]
      */
-    public function items($owner, $repository, $startReference, $endReference)
+    public function items($owner, $repository, $startReference, $endReference = null)
     {
         if ($startReference === $endReference) {
             return [];
@@ -40,19 +40,25 @@ class CommitRepository
             return [];
         }
 
-        $end = $this->show(
-            $owner,
-            $repository,
-            $endReference
-        );
+        $params = [];
 
-        if (null === $end) {
-            return [];
+        if ($endReference !== null) {
+            $end = $this->show(
+                $owner,
+                $repository,
+                $endReference
+            );
+
+            if (null === $end) {
+                return [];
+            }
+
+            $params = [
+                'sha' => $end->sha(),
+            ];
         }
 
-        $commits = $this->all($owner, $repository, [
-            'sha' => $end->sha(),
-        ]);
+        $commits = $this->all($owner, $repository, $params);
 
         $range = [];
 

--- a/src/Repository/PullRequestRepository.php
+++ b/src/Repository/PullRequestRepository.php
@@ -51,10 +51,10 @@ class PullRequestRepository
      * @param string $owner
      * @param string $repository
      * @param string $startReference
-     * @param string $endReference
+     * @param string|null $endReference
      * @return Entity\PullRequest[] array
      */
-    public function items($owner, $repository, $startReference, $endReference)
+    public function items($owner, $repository, $startReference, $endReference = null)
     {
         $commits = $this->commitRepository->items(
             $owner,

--- a/tests/Console/PullRequestCommandTest.php
+++ b/tests/Console/PullRequestCommandTest.php
@@ -105,7 +105,7 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
             ],
             [
                 'end-reference',
-                true,
+                false,
                 'The end reference, e.g. "1.1.0"',
             ],
         ];

--- a/tests/Repository/PullRequestRepositoryTest.php
+++ b/tests/Repository/PullRequestRepositoryTest.php
@@ -89,6 +89,42 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
         $this->assertNull($pullRequest);
     }
 
+    public function testItemsDoesNotRequireAnEndReference()
+    {
+        $faker = $this->faker();
+
+        $vendor = $faker->userName;
+        $package = $faker->slug();
+        $startReference = $faker->sha1;
+
+        $commitRepository = $this->commitRepository();
+
+        $commitRepository
+            ->expects($this->once())
+            ->method('items')
+            ->with(
+                $this->equalTo($vendor),
+                $this->equalTo($package),
+                $this->equalTo($startReference),
+                $this->equalTo(null)
+            )
+            ->willReturn([])
+        ;
+
+        $repository = new Repository\PullRequestRepository(
+            $this->pullRequestApi(),
+            $commitRepository
+        );
+
+        $pullRequests = $repository->items(
+            $vendor,
+            $package,
+            $startReference
+        );
+
+        $this->assertSame([], $pullRequests);
+    }
+
     public function testItemsReturnsEmptyArrayIfNoCommitsWereFound()
     {
         $faker = $this->faker();


### PR DESCRIPTION
This PR

* [x] makes `end-reference` an optional argument to the console command