### PR TITLE
Fix: Add it and composer targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+it: cs test
+
 cs:
 	vendor/bin/php-cs-fixer fix --verbose --diff
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 it: cs test
 
-cs:
+composer:
+	composer install
+
+cs: composer
 	vendor/bin/php-cs-fixer fix --verbose --diff
 
-test:
+test: composer
 	vendor/bin/phpunit


### PR DESCRIPTION
This PR

* [x] adds an `it` target, depending on `cs` and `test` targets, and makes it the first target
* [x] adds a `composer` target, and makes the `cs` and `test` targets depend on it

:information_desk_person: Run

```
$ make
```