### PR TITLE
Fix: Guard against invalid values

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^5.5 || ^7.0",
+        "beberlei/assert": "^2.4",
         "codeclimate/php-test-reporter": "0.2.0",
         "knplabs/github-api": "^1.4.14",
         "symfony/console": "^2.7.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,62 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "7b4df4174f01fc7de108655e9df248d7",
-    "content-hash": "2e62a9d65a78e06c7469adcd8959efa2",
+    "hash": "259d755ca875a7274bd78c50b008a294",
+    "content-hash": "883f0da23a214e480ea7e011c4b6001e",
     "packages": [
+        {
+            "name": "beberlei/assert",
+            "version": "v2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/beberlei/assert.git",
+                "reference": "7281b1fd8118b31cb9162c2fb5a4cc6f01d62ed6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/beberlei/assert/zipball/7281b1fd8118b31cb9162c2fb5a4cc6f01d62ed6",
+                "reference": "7281b1fd8118b31cb9162c2fb5a4cc6f01d62ed6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "@stable"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Assert": "lib/"
+                },
+                "files": [
+                    "lib/Assert/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                }
+            ],
+            "description": "Thin assertion library for input validation in business models.",
+            "keywords": [
+                "assert",
+                "assertion",
+                "validation"
+            ],
+            "time": "2015-08-21 16:50:17"
+        },
         {
             "name": "codeclimate/php-test-reporter",
             "version": "v0.2.0",

--- a/src/Resource/Commit.php
+++ b/src/Resource/Commit.php
@@ -9,6 +9,8 @@
 
 namespace Localheinz\GitHub\ChangeLog\Resource;
 
+use Assert\Assertion;
+
 final class Commit implements CommitInterface
 {
     /**
@@ -27,6 +29,10 @@ final class Commit implements CommitInterface
      */
     public function __construct($sha, $message)
     {
+        Assertion::string($sha);
+        Assertion::regex($sha, '/^[0-9a-f]{40}$/i');
+        Assertion::string($message);
+
         $this->sha = $sha;
         $this->message = $message;
     }

--- a/src/Resource/PullRequest.php
+++ b/src/Resource/PullRequest.php
@@ -9,6 +9,8 @@
 
 namespace Localheinz\GitHub\ChangeLog\Resource;
 
+use Assert\Assertion;
+
 final class PullRequest implements PullRequestInterface
 {
     /**
@@ -27,6 +29,10 @@ final class PullRequest implements PullRequestInterface
      */
     public function __construct($id, $title)
     {
+        Assertion::integerish($id);
+        Assertion::greaterThan($id, 0);
+        Assertion::string($title);
+
         $this->id = $id;
         $this->title = $title;
     }

--- a/test/Repository/CommitRepositoryTest.php
+++ b/test/Repository/CommitRepositoryTest.php
@@ -471,7 +471,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         $commitApi = $this->commitApi();
 
         $startCommit = $this->commitItem();
-        $startCommit->sha = 'start';
+        $startCommit->sha = $faker->sha1;
 
         $commitApi
             ->expects($this->at(0))
@@ -485,7 +485,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         ;
 
         $endCommit = $this->commitItem();
-        $endCommit->sha = 'end';
+        $endCommit->sha = $faker->sha1;
 
         $commitApi
             ->expects($this->at(1))
@@ -563,7 +563,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         $commitApi = $this->commitApi();
 
         $startCommit = $this->commitItem();
-        $startCommit->sha = 'start';
+        $startCommit->sha = $faker->sha1;
 
         $commitApi
             ->expects($this->at(0))
@@ -577,7 +577,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         ;
 
         $endCommit = $this->commitItem();
-        $endCommit->sha = 'end';
+        $endCommit->sha = $faker->sha1;
 
         $commitApi
             ->expects($this->at(1))

--- a/test/Resource/CommitTest.php
+++ b/test/Resource/CommitTest.php
@@ -9,6 +9,7 @@
 
 namespace Localheinz\GitHub\ChangeLog\Test\Resource;
 
+use InvalidArgumentException;
 use Localheinz\GitHub\ChangeLog\Resource;
 use Localheinz\GitHub\ChangeLog\Resource\Commit;
 use Localheinz\GitHub\ChangeLog\Resource\CommitInterface;
@@ -31,6 +32,82 @@ class CommitTest extends PHPUnit_Framework_TestCase
         $reflectionClass = new \ReflectionClass(Commit::class);
 
         $this->assertTrue($reflectionClass->implementsInterface(CommitInterface::class));
+    }
+
+    /**
+     * @dataProvider providerInvalidSha
+     *
+     * @param mixed $sha
+     */
+    public function testConstructorRejectsInvalidSha($sha)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $message = $this->getFaker()->sentence();
+
+        new Resource\Commit(
+            $sha,
+            $message
+        );
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerInvalidSha()
+    {
+        $faker = $this->getFaker();
+
+        $values = [
+            new \stdClass(),
+            $faker->randomNumber(),
+            $faker->randomFloat(),
+            $faker->word,
+            $faker->words,
+            $faker->md5,
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider providerInvalidMessage
+     *
+     * @param mixed $message
+     */
+    public function testConstructorRejectsInvalidMessage($message)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $sha = $this->getFaker()->sha1;
+
+        new Resource\Commit(
+            $sha,
+            $message
+        );
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerInvalidMessage()
+    {
+        $faker = $this->getFaker();
+
+        $values = [
+            new \stdClass(),
+            $faker->words,
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
     }
 
     public function testConstructorSetsShaAndMessage()

--- a/test/Resource/PullRequestTest.php
+++ b/test/Resource/PullRequestTest.php
@@ -9,6 +9,7 @@
 
 namespace Localheinz\GitHub\ChangeLog\Test\Resource;
 
+use InvalidArgumentException;
 use Localheinz\GitHub\ChangeLog\Resource;
 use Localheinz\GitHub\ChangeLog\Resource\PullRequest;
 use Localheinz\GitHub\ChangeLog\Resource\PullRequestInterface;
@@ -31,6 +32,85 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
         $reflectionClass = new \ReflectionClass(PullRequest::class);
 
         $this->assertTrue($reflectionClass->implementsInterface(PullRequestInterface::class));
+    }
+
+    /**
+     * @dataProvider providerInvalidId
+     *
+     * @param mixed $id
+     */
+    public function testConstructorRejectsInvalidId($id)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $title = $this->getFaker()->sentence();
+
+        new Resource\PullRequest(
+            $id,
+            $title
+        );
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerInvalidId()
+    {
+        $faker = $this->getFaker();
+
+        $values = [
+            new \stdClass(),
+            $faker->randomFloat(),
+            0,
+            -1 * $faker->numberBetween(1),
+            $faker->word,
+            $faker->words,
+            $faker->md5,
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider providerInvalidTitle
+     *
+     * @param mixed $message
+     */
+    public function testConstructorRejectsInvalidTitle($message)
+    {
+        $this->setExpectedException(InvalidArgumentException::class);
+
+        $sha = sha1($this->getFaker()->sentence());
+
+        new Resource\PullRequest(
+            $sha,
+            $message
+        );
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function providerInvalidTitle()
+    {
+        $faker = $this->getFaker();
+
+        $values = [
+            new \stdClass(),
+            $faker->randomFloat(),
+            $faker->randomNumber(),
+            $faker->words,
+        ];
+
+        foreach ($values as $value) {
+            yield [
+                $value,
+            ];
+        }
     }
 
     public function testConstructorSetsIdAndTitle()


### PR DESCRIPTION
This PR

* [x] requires `beberlei/assert`
* [x] uses assertions to guard against injecting invalid values