### PR TITLE
Fix: Shift environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ matrix:
   fast_finish: true
   include:
     - php: 5.5
-      env: WITH_CS=true
     - php: 5.6
-      env: WITH_COVERAGE=true
+      env: WITH_CS=true
     - php: 7
+      env: WITH_COVERAGE=true
     - php: hhvm
 
 cache:


### PR DESCRIPTION
This PR

* [x] shifts environment variables forward

:information_desk_person: PHP5.5 is dead, right?