### PR TITLE
Fix: Rename Entity to Resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ require 'vendor/autoload.php';
 
 use Github\Client;
 use Github\HttpClient\CachedHttpClient;
-use Localheinz\GitHub\ChangeLog\Entity;
 use Localheinz\GitHub\ChangeLog\Repository;
+use Localheinz\GitHub\ChangeLog\Resource;
 
 $client = new Client(new CachedHttpClient());
 $client->authenticate(
@@ -93,7 +93,7 @@ $pullRequests = $repository->items(
     '0.1.2'
 );
 
-array_walk($pullRequests, function (Entity\PullRequest $pullRequest) {
+array_walk($pullRequests, function (Resource\PullRequest $pullRequest) {
     echo sprintf(
         '- %s (#%s)' . PHP_EOL,
         $pullRequest->title(),

--- a/src/Console/PullRequestCommand.php
+++ b/src/Console/PullRequestCommand.php
@@ -13,8 +13,8 @@ use Exception;
 use Github\Api;
 use Github\Client;
 use Github\HttpClient;
-use Localheinz\GitHub\ChangeLog\Entity;
 use Localheinz\GitHub\ChangeLog\Repository;
+use Localheinz\GitHub\ChangeLog\Resource;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input;
 use Symfony\Component\Console\Output;
@@ -153,7 +153,7 @@ class PullRequestCommand extends Command
 
             $template = $input->getOption('template');
 
-            array_walk($pullRequests, function (Entity\PullRequest $pullRequest) use ($output, $template) {
+            array_walk($pullRequests, function (Resource\PullRequest $pullRequest) use ($output, $template) {
 
                 $message = str_replace(
                     [

--- a/src/Repository/CommitRepository.php
+++ b/src/Repository/CommitRepository.php
@@ -10,7 +10,7 @@
 namespace Localheinz\GitHub\ChangeLog\Repository;
 
 use Github\Api;
-use Localheinz\GitHub\ChangeLog\Entity;
+use Localheinz\GitHub\ChangeLog\Resource;
 
 class CommitRepository
 {
@@ -30,7 +30,7 @@ class CommitRepository
      * @param string      $startReference
      * @param string|null $endReference
      *
-     * @return Entity\Commit[]
+     * @return Resource\Commit[]
      */
     public function items($owner, $repository, $startReference, $endReference = null)
     {
@@ -73,10 +73,10 @@ class CommitRepository
         $tail = null;
 
         while (count($commits)) {
-            /* @var Entity\Commit $commit */
+            /* @var Resource\Commit $commit */
             $commit = array_shift($commits);
 
-            if ($tail instanceof Entity\Commit && $commit->sha() === $tail->sha()) {
+            if ($tail instanceof Resource\Commit && $commit->sha() === $tail->sha()) {
                 continue;
             }
 
@@ -103,7 +103,7 @@ class CommitRepository
      * @param string $repository
      * @param string $sha
      *
-     * @return Entity\Commit|null
+     * @return Resource\Commit|null
      */
     public function show($owner, $repository, $sha)
     {
@@ -117,7 +117,7 @@ class CommitRepository
             return;
         }
 
-        return new Entity\Commit(
+        return new Resource\Commit(
             $response['sha'],
             $response['commit']['message']
         );
@@ -128,7 +128,7 @@ class CommitRepository
      * @param string $repository
      * @param array  $params
      *
-     * @return Entity\Commit[]
+     * @return Resource\Commit[]
      */
     public function all($owner, $repository, array $params = [])
     {
@@ -149,7 +149,7 @@ class CommitRepository
         $commits = [];
 
         array_walk($response, function ($data) use (&$commits) {
-            $commit = new Entity\Commit(
+            $commit = new Resource\Commit(
                 $data['sha'],
                 $data['commit']['message']
             );

--- a/src/Repository/PullRequestRepository.php
+++ b/src/Repository/PullRequestRepository.php
@@ -10,7 +10,7 @@
 namespace Localheinz\GitHub\ChangeLog\Repository;
 
 use Github\Api;
-use Localheinz\GitHub\ChangeLog\Entity;
+use Localheinz\GitHub\ChangeLog\Resource;
 
 class PullRequestRepository
 {
@@ -35,7 +35,7 @@ class PullRequestRepository
      * @param string $repository
      * @param string $id
      *
-     * @return Entity\PullRequest|null
+     * @return Resource\PullRequest|null
      */
     public function show($owner, $repository, $id)
     {
@@ -49,7 +49,7 @@ class PullRequestRepository
             return;
         }
 
-        return new Entity\PullRequest(
+        return new Resource\PullRequest(
             $response['number'],
             $response['title']
         );
@@ -61,7 +61,7 @@ class PullRequestRepository
      * @param string      $startReference
      * @param string|null $endReference
      *
-     * @return Entity\PullRequest[] array
+     * @return Resource\PullRequest[] array
      */
     public function items($owner, $repository, $startReference, $endReference = null)
     {
@@ -74,7 +74,7 @@ class PullRequestRepository
 
         $pullRequests = [];
 
-        array_walk($commits, function (Entity\Commit $commit) use (&$pullRequests, $owner, $repository) {
+        array_walk($commits, function (Resource\Commit $commit) use (&$pullRequests, $owner, $repository) {
 
             if (0 === preg_match('/^Merge pull request #(?P<id>\d+)/', $commit->message(), $matches)) {
                 return;

--- a/src/Resource/Commit.php
+++ b/src/Resource/Commit.php
@@ -7,7 +7,7 @@
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace Localheinz\GitHub\ChangeLog\Entity;
+namespace Localheinz\GitHub\ChangeLog\Resource;
 
 class Commit
 {

--- a/src/Resource/PullRequest.php
+++ b/src/Resource/PullRequest.php
@@ -7,7 +7,7 @@
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace Localheinz\GitHub\ChangeLog\Entity;
+namespace Localheinz\GitHub\ChangeLog\Resource;
 
 class PullRequest
 {

--- a/test/Console/PullRequestCommandTest.php
+++ b/test/Console/PullRequestCommandTest.php
@@ -13,8 +13,8 @@ use Exception;
 use Github\Client;
 use Github\HttpClient;
 use Localheinz\GitHub\ChangeLog\Console;
-use Localheinz\GitHub\ChangeLog\Entity;
 use Localheinz\GitHub\ChangeLog\Repository;
+use Localheinz\GitHub\ChangeLog\Resource;
 use PHPUnit_Framework_MockObject_MockObject;
 use PHPUnit_Framework_TestCase;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
@@ -415,7 +415,7 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
             '',
         ];
 
-        array_walk($pullRequests, function (Entity\PullRequest $pullRequest) use (&$expectedMessages, $template) {
+        array_walk($pullRequests, function (Resource\PullRequest $pullRequest) use (&$expectedMessages, $template) {
             $expectedMessages[] = str_replace(
                 [
                     '%title%',
@@ -639,7 +639,7 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return Entity\PullRequest
+     * @return Resource\PullRequest
      */
     private function pullRequest()
     {
@@ -648,7 +648,7 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
         $id = $faker->unique()->randomNumber();
         $title = $faker->unique()->sentence();
 
-        return new Entity\PullRequest(
+        return new Resource\PullRequest(
             $id,
             $title
         );
@@ -657,7 +657,7 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
     /**
      * @param int $count
      *
-     * @return Entity\PullRequest[]
+     * @return Resource\PullRequest[]
      */
     private function pullRequests($count)
     {

--- a/test/Repository/CommitRepositoryTest.php
+++ b/test/Repository/CommitRepositoryTest.php
@@ -10,8 +10,8 @@
 namespace Localheinz\GitHub\ChangeLog\Test\Repository;
 
 use Github\Api;
-use Localheinz\GitHub\ChangeLog\Entity;
 use Localheinz\GitHub\ChangeLog\Repository;
+use Localheinz\GitHub\ChangeLog\Resource;
 use PHPUnit_Framework_MockObject_MockObject;
 use PHPUnit_Framework_TestCase;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
@@ -52,7 +52,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
             $sha
         );
 
-        $this->assertInstanceOf(Entity\Commit::class, $commit);
+        $this->assertInstanceOf(Resource\Commit::class, $commit);
 
         $this->assertSame($expectedItem->sha, $commit->sha());
         $this->assertSame($expectedItem->message, $commit->message());
@@ -234,9 +234,9 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         array_walk($commits, function ($commit) use (&$expectedItems) {
             $expectedItem = array_shift($expectedItems);
 
-            $this->assertInstanceOf(Entity\Commit::class, $commit);
+            $this->assertInstanceOf(Resource\Commit::class, $commit);
 
-            /* @var Entity\Commit $commit */
+            /* @var Resource\Commit $commit */
             $this->assertSame($expectedItem->sha, $commit->sha());
             $this->assertSame($expectedItem->message, $commit->message());
         });
@@ -543,9 +543,9 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         array_walk($commits, function ($commit) use (&$expectedItems) {
             $expectedItem = array_shift($expectedItems);
 
-            $this->assertInstanceOf(Entity\Commit::class, $commit);
+            $this->assertInstanceOf(Resource\Commit::class, $commit);
 
-            /* @var Entity\Commit $commit */
+            /* @var Resource\Commit $commit */
             $this->assertSame($expectedItem->sha, $commit->sha());
             $this->assertSame($expectedItem->message, $commit->message());
         });
@@ -660,9 +660,9 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         array_walk($commits, function ($commit) use (&$expectedItems) {
             $expectedItem = array_shift($expectedItems);
 
-            $this->assertInstanceOf(Entity\Commit::class, $commit);
+            $this->assertInstanceOf(Resource\Commit::class, $commit);
 
-            /* @var Entity\Commit $commit */
+            /* @var Resource\Commit $commit */
             $this->assertSame($expectedItem->sha, $commit->sha());
             $this->assertSame($expectedItem->message, $commit->message());
         });

--- a/test/Repository/PullRequestRepositoryTest.php
+++ b/test/Repository/PullRequestRepositoryTest.php
@@ -10,8 +10,8 @@
 namespace Localheinz\GitHub\ChangeLog\Test\Repository;
 
 use Github\Api;
-use Localheinz\GitHub\ChangeLog\Entity;
 use Localheinz\GitHub\ChangeLog\Repository;
+use Localheinz\GitHub\ChangeLog\Resource;
 use PHPUnit_Framework_MockObject_MockObject;
 use PHPUnit_Framework_TestCase;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
@@ -54,7 +54,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
             $expectedItem->id
         );
 
-        $this->assertInstanceOf(Entity\PullRequest::class, $pullRequest);
+        $this->assertInstanceOf(Resource\PullRequest::class, $pullRequest);
 
         $this->assertSame($expectedItem->id, $pullRequest->id());
         $this->assertSame($expectedItem->title, $pullRequest->title());
@@ -180,7 +180,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
 
         $commitRepository = $this->commitRepository();
 
-        $commit = new Entity\Commit(
+        $commit = new Resource\Commit(
             $faker->sha1,
             'I am not a merge commit'
         );
@@ -227,7 +227,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
 
         $expectedItem = $this->pullRequestItem();
 
-        $mergeCommit = new Entity\Commit(
+        $mergeCommit = new Resource\Commit(
             $this->getFaker()->unique()->sha1,
             sprintf(
                 'Merge pull request #%s from localheinz/fix/directory',
@@ -279,9 +279,9 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
 
         $pullRequest = array_shift($pullRequests);
 
-        $this->assertInstanceOf(Entity\PullRequest::class, $pullRequest);
+        $this->assertInstanceOf(Resource\PullRequest::class, $pullRequest);
 
-        /* @var Entity\PullRequest $pullRequest */
+        /* @var Resource\PullRequest $pullRequest */
         $this->assertSame($expectedItem->id, $pullRequest->id());
         $this->assertSame($expectedItem->title, $pullRequest->title());
     }
@@ -299,7 +299,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
 
         $id = 9000;
 
-        $mergeCommit = new Entity\Commit(
+        $mergeCommit = new Resource\Commit(
             $faker->sha1,
             sprintf(
                 'Merge pull request #%s from localheinz/fix/directory',

--- a/test/Resource/CommitTest.php
+++ b/test/Resource/CommitTest.php
@@ -7,9 +7,9 @@
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace Localheinz\GitHub\ChangeLog\Test\Entity;
+namespace Localheinz\GitHub\ChangeLog\Test\Resource;
 
-use Localheinz\GitHub\ChangeLog\Entity;
+use Localheinz\GitHub\ChangeLog\Resource;
 use PHPUnit_Framework_TestCase;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
@@ -24,7 +24,7 @@ class CommitTest extends PHPUnit_Framework_TestCase
         $sha = $faker->sha1;
         $message = $faker->sentence();
 
-        $entity = new Entity\Commit(
+        $entity = new Resource\Commit(
             $sha,
             $message
         );

--- a/test/Resource/PullRequestTest.php
+++ b/test/Resource/PullRequestTest.php
@@ -7,9 +7,9 @@
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace Localheinz\GitHub\ChangeLog\Test\Entity;
+namespace Localheinz\GitHub\ChangeLog\Test\Resource;
 
-use Localheinz\GitHub\ChangeLog\Entity;
+use Localheinz\GitHub\ChangeLog\Resource;
 use PHPUnit_Framework_TestCase;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
@@ -24,7 +24,7 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
         $id = $faker->randomNumber();
         $title = $faker->sentence();
 
-        $entity = new Entity\PullRequest(
+        $entity = new Resource\PullRequest(
             $id,
             $title
         );


### PR DESCRIPTION
This PR

* [x] renames `Entity` to `Resource`