### PR TITLE
Fix: Extract interfaces and mark value objects as final

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $pullRequests = $repository->items(
     '0.1.2'
 );
 
-array_walk($pullRequests, function (Resource\PullRequest $pullRequest) {
+array_walk($pullRequests, function (Resource\PullRequestInterface $pullRequest) {
     echo sprintf(
         '- %s (#%s)' . PHP_EOL,
         $pullRequest->title(),

--- a/src/Console/PullRequestCommand.php
+++ b/src/Console/PullRequestCommand.php
@@ -153,7 +153,7 @@ class PullRequestCommand extends Command
 
             $template = $input->getOption('template');
 
-            array_walk($pullRequests, function (Resource\PullRequest $pullRequest) use ($output, $template) {
+            array_walk($pullRequests, function (Resource\PullRequestInterface $pullRequest) use ($output, $template) {
 
                 $message = str_replace(
                     [

--- a/src/Repository/CommitRepository.php
+++ b/src/Repository/CommitRepository.php
@@ -30,7 +30,7 @@ class CommitRepository
      * @param string      $startReference
      * @param string|null $endReference
      *
-     * @return Resource\Commit[]
+     * @return Resource\CommitInterface[]
      */
     public function items($owner, $repository, $startReference, $endReference = null)
     {
@@ -73,10 +73,10 @@ class CommitRepository
         $tail = null;
 
         while (count($commits)) {
-            /* @var Resource\Commit $commit */
+            /* @var Resource\CommitInterface $commit */
             $commit = array_shift($commits);
 
-            if ($tail instanceof Resource\Commit && $commit->sha() === $tail->sha()) {
+            if ($tail instanceof Resource\CommitInterface && $commit->sha() === $tail->sha()) {
                 continue;
             }
 
@@ -103,7 +103,7 @@ class CommitRepository
      * @param string $repository
      * @param string $sha
      *
-     * @return Resource\Commit|null
+     * @return Resource\CommitInterface|null
      */
     public function show($owner, $repository, $sha)
     {
@@ -128,7 +128,7 @@ class CommitRepository
      * @param string $repository
      * @param array  $params
      *
-     * @return Resource\Commit[]
+     * @return Resource\CommitInterface[]
      */
     public function all($owner, $repository, array $params = [])
     {

--- a/src/Repository/PullRequestRepository.php
+++ b/src/Repository/PullRequestRepository.php
@@ -35,7 +35,7 @@ class PullRequestRepository
      * @param string $repository
      * @param string $id
      *
-     * @return Resource\PullRequest|null
+     * @return Resource\PullRequestInterface|null
      */
     public function show($owner, $repository, $id)
     {
@@ -61,7 +61,7 @@ class PullRequestRepository
      * @param string      $startReference
      * @param string|null $endReference
      *
-     * @return Resource\PullRequest[] array
+     * @return Resource\PullRequestInterface[] array
      */
     public function items($owner, $repository, $startReference, $endReference = null)
     {
@@ -74,7 +74,7 @@ class PullRequestRepository
 
         $pullRequests = [];
 
-        array_walk($commits, function (Resource\Commit $commit) use (&$pullRequests, $owner, $repository) {
+        array_walk($commits, function (Resource\CommitInterface $commit) use (&$pullRequests, $owner, $repository) {
 
             if (0 === preg_match('/^Merge pull request #(?P<id>\d+)/', $commit->message(), $matches)) {
                 return;

--- a/src/Resource/Commit.php
+++ b/src/Resource/Commit.php
@@ -9,7 +9,7 @@
 
 namespace Localheinz\GitHub\ChangeLog\Resource;
 
-class Commit
+final class Commit implements CommitInterface
 {
     /**
      * @var string
@@ -31,17 +31,11 @@ class Commit
         $this->message = $message;
     }
 
-    /**
-     * @return string
-     */
     public function sha()
     {
         return $this->sha;
     }
 
-    /**
-     * @return string
-     */
     public function message()
     {
         return $this->message;

--- a/src/Resource/CommitInterface.php
+++ b/src/Resource/CommitInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Andreas Möller <am@localheinz.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Localheinz\GitHub\ChangeLog\Resource;
+
+interface CommitInterface
+{
+    /**
+     * @return string
+     */
+    public function sha();
+
+    /**
+     * @return string
+     */
+    public function message();
+}

--- a/src/Resource/PullRequest.php
+++ b/src/Resource/PullRequest.php
@@ -9,7 +9,7 @@
 
 namespace Localheinz\GitHub\ChangeLog\Resource;
 
-class PullRequest
+final class PullRequest implements PullRequestInterface
 {
     /**
      * @var string
@@ -31,17 +31,11 @@ class PullRequest
         $this->title = $title;
     }
 
-    /**
-     * @return string
-     */
     public function id()
     {
         return $this->id;
     }
 
-    /**
-     * @return string
-     */
     public function title()
     {
         return $this->title;

--- a/src/Resource/PullRequestInterface.php
+++ b/src/Resource/PullRequestInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Copyright (c) 2016 Andreas Möller <am@localheinz.com>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Localheinz\GitHub\ChangeLog\Resource;
+
+interface PullRequestInterface
+{
+    /**
+     * @return string
+     */
+    public function id();
+
+    /**
+     * @return string
+     */
+    public function title();
+}

--- a/test/Console/PullRequestCommandTest.php
+++ b/test/Console/PullRequestCommandTest.php
@@ -415,7 +415,7 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
             '',
         ];
 
-        array_walk($pullRequests, function (Resource\PullRequest $pullRequest) use (&$expectedMessages, $template) {
+        array_walk($pullRequests, function (Resource\PullRequestInterface $pullRequest) use (&$expectedMessages, $template) {
             $expectedMessages[] = str_replace(
                 [
                     '%title%',

--- a/test/Repository/CommitRepositoryTest.php
+++ b/test/Repository/CommitRepositoryTest.php
@@ -52,7 +52,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
             $sha
         );
 
-        $this->assertInstanceOf(Resource\Commit::class, $commit);
+        $this->assertInstanceOf(Resource\CommitInterface::class, $commit);
 
         $this->assertSame($expectedItem->sha, $commit->sha());
         $this->assertSame($expectedItem->message, $commit->message());
@@ -234,9 +234,9 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         array_walk($commits, function ($commit) use (&$expectedItems) {
             $expectedItem = array_shift($expectedItems);
 
-            $this->assertInstanceOf(Resource\Commit::class, $commit);
+            $this->assertInstanceOf(Resource\CommitInterface::class, $commit);
 
-            /* @var Resource\Commit $commit */
+            /* @var Resource\CommitInterface $commit */
             $this->assertSame($expectedItem->sha, $commit->sha());
             $this->assertSame($expectedItem->message, $commit->message());
         });
@@ -543,9 +543,9 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         array_walk($commits, function ($commit) use (&$expectedItems) {
             $expectedItem = array_shift($expectedItems);
 
-            $this->assertInstanceOf(Resource\Commit::class, $commit);
+            $this->assertInstanceOf(Resource\CommitInterface::class, $commit);
 
-            /* @var Resource\Commit $commit */
+            /* @var Resource\CommitInterface $commit */
             $this->assertSame($expectedItem->sha, $commit->sha());
             $this->assertSame($expectedItem->message, $commit->message());
         });
@@ -660,9 +660,9 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         array_walk($commits, function ($commit) use (&$expectedItems) {
             $expectedItem = array_shift($expectedItems);
 
-            $this->assertInstanceOf(Resource\Commit::class, $commit);
+            $this->assertInstanceOf(Resource\CommitInterface::class, $commit);
 
-            /* @var Resource\Commit $commit */
+            /* @var Resource\CommitInterface $commit */
             $this->assertSame($expectedItem->sha, $commit->sha());
             $this->assertSame($expectedItem->message, $commit->message());
         });

--- a/test/Repository/PullRequestRepositoryTest.php
+++ b/test/Repository/PullRequestRepositoryTest.php
@@ -54,7 +54,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
             $expectedItem->id
         );
 
-        $this->assertInstanceOf(Resource\PullRequest::class, $pullRequest);
+        $this->assertInstanceOf(Resource\PullRequestInterface::class, $pullRequest);
 
         $this->assertSame($expectedItem->id, $pullRequest->id());
         $this->assertSame($expectedItem->title, $pullRequest->title());
@@ -279,9 +279,9 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
 
         $pullRequest = array_shift($pullRequests);
 
-        $this->assertInstanceOf(Resource\PullRequest::class, $pullRequest);
+        $this->assertInstanceOf(Resource\PullRequestInterface::class, $pullRequest);
 
-        /* @var Resource\PullRequest $pullRequest */
+        /* @var Resource\PullRequestInterface $pullRequest */
         $this->assertSame($expectedItem->id, $pullRequest->id());
         $this->assertSame($expectedItem->title, $pullRequest->title());
     }

--- a/test/Resource/CommitTest.php
+++ b/test/Resource/CommitTest.php
@@ -10,12 +10,28 @@
 namespace Localheinz\GitHub\ChangeLog\Test\Resource;
 
 use Localheinz\GitHub\ChangeLog\Resource;
+use Localheinz\GitHub\ChangeLog\Resource\Commit;
+use Localheinz\GitHub\ChangeLog\Resource\CommitInterface;
 use PHPUnit_Framework_TestCase;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
 class CommitTest extends PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
+
+    public function testIsFinal()
+    {
+        $reflectionClass = new \ReflectionClass(Commit::class);
+
+        $this->assertTrue($reflectionClass->isFinal());
+    }
+
+    public function testImplementsCommitInterface()
+    {
+        $reflectionClass = new \ReflectionClass(Commit::class);
+
+        $this->assertTrue($reflectionClass->implementsInterface(CommitInterface::class));
+    }
 
     public function testConstructorSetsShaAndMessage()
     {

--- a/test/Resource/PullRequestTest.php
+++ b/test/Resource/PullRequestTest.php
@@ -10,12 +10,28 @@
 namespace Localheinz\GitHub\ChangeLog\Test\Resource;
 
 use Localheinz\GitHub\ChangeLog\Resource;
+use Localheinz\GitHub\ChangeLog\Resource\PullRequest;
+use Localheinz\GitHub\ChangeLog\Resource\PullRequestInterface;
 use PHPUnit_Framework_TestCase;
 use Refinery29\Test\Util\Faker\GeneratorTrait;
 
 class PullRequestTest extends PHPUnit_Framework_TestCase
 {
     use GeneratorTrait;
+
+    public function testIsFinal()
+    {
+        $reflectionClass = new \ReflectionClass(PullRequest::class);
+
+        $this->assertTrue($reflectionClass->isFinal());
+    }
+
+    public function testImplementsPullRequestInterface()
+    {
+        $reflectionClass = new \ReflectionClass(PullRequest::class);
+
+        $this->assertTrue($reflectionClass->implementsInterface(PullRequestInterface::class));
+    }
 
     public function testConstructorSetsIdAndTitle()
     {


### PR DESCRIPTION
This PR

* [x] extracts interfaces and marks resources as `final`