### PR TITLE
Fix: Id needs to be greater than 0

### DIFF
--- a/test/Resource/PullRequestTest.php
+++ b/test/Resource/PullRequestTest.php
@@ -117,7 +117,7 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
     {
         $faker = $this->getFaker();
 
-        $id = $faker->randomNumber();
+        $id = $faker->numberBetween(1);
         $title = $faker->sentence();
 
         $entity = new Resource\PullRequest(


### PR DESCRIPTION
This PR

* [x] fixes a test as `$faker->randomNumber()` may yield `0` which is not greater than `0`

Follows #79.