### PR TITLE
Fix: Rename variables in tests

### DIFF
--- a/test/Resource/CommitTest.php
+++ b/test/Resource/CommitTest.php
@@ -117,12 +117,12 @@ class CommitTest extends PHPUnit_Framework_TestCase
         $sha = $faker->sha1;
         $message = $faker->sentence();
 
-        $entity = new Resource\Commit(
+        $commit = new Resource\Commit(
             $sha,
             $message
         );
 
-        $this->assertSame($sha, $entity->sha());
-        $this->assertSame($message, $entity->message());
+        $this->assertSame($sha, $commit->sha());
+        $this->assertSame($message, $commit->message());
     }
 }

--- a/test/Resource/PullRequestTest.php
+++ b/test/Resource/PullRequestTest.php
@@ -120,12 +120,12 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
         $id = $faker->numberBetween(1);
         $title = $faker->sentence();
 
-        $entity = new Resource\PullRequest(
+        $pullRequest = new Resource\PullRequest(
             $id,
             $title
         );
 
-        $this->assertSame($id, $entity->id());
-        $this->assertSame($title, $entity->title());
+        $this->assertSame($id, $pullRequest->id());
+        $this->assertSame($title, $pullRequest->title());
     }
 }


### PR DESCRIPTION
This PR

* [x] renames variables in tests