### PR TITLE
Fix: Pull mutators into interface

### DIFF
--- a/src/Resource/Range.php
+++ b/src/Resource/Range.php
@@ -31,11 +31,6 @@ final class Range implements RangeInterface
         return $this->pullRequests;
     }
 
-    /**
-     * @param CommitInterface $commit
-     *
-     * @return static
-     */
     public function withCommit(CommitInterface $commit)
     {
         $commits = $this->commits;
@@ -47,11 +42,6 @@ final class Range implements RangeInterface
         return $instance;
     }
 
-    /**
-     * @param PullRequestInterface $pullRequest
-     *
-     * @return static
-     */
     public function withPullRequest(PullRequestInterface $pullRequest)
     {
         $pullRequests = $this->pullRequests();

--- a/src/Resource/RangeInterface.php
+++ b/src/Resource/RangeInterface.php
@@ -20,4 +20,18 @@ interface RangeInterface
      * @return PullRequestInterface[]
      */
     public function pullRequests();
+
+    /**
+     * @param CommitInterface $commit
+     *
+     * @return static
+     */
+    public function withCommit(CommitInterface $commit);
+
+    /**
+     * @param PullRequestInterface $pullRequest
+     *
+     * @return static
+     */
+    public function withPullRequest(PullRequestInterface $pullRequest);
 }


### PR DESCRIPTION
This PR

* [x] pulls mutators into `RangeInterface`

Follows #98.