### PR TITLE
Fix: Rename methods returning mocks

### DIFF
--- a/test/Console/PullRequestCommandTest.php
+++ b/test/Console/PullRequestCommandTest.php
@@ -161,7 +161,7 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
     {
         $authToken = $this->getFaker()->password();
 
-        $client = $this->clientMock();
+        $client = $this->getClientMock();
 
         $client
             ->expects($this->once())
@@ -172,12 +172,12 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
             )
         ;
 
-        $pullRequestRepository = $this->pullRequestRepositoryMock();
+        $pullRequestRepository = $this->getPullRequestRepositoryMock();
 
         $pullRequestRepository
             ->expects($this->any())
             ->method('items')
-            ->willReturn($this->rangeMock())
+            ->willReturn($this->getRangeMock())
         ;
 
         $command = new Console\PullRequestCommand(
@@ -215,7 +215,7 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
         $startReference = $faker->unique()->sha1;
         $endReference = $faker->unique()->sha1;
 
-        $pullRequestRepository = $this->pullRequestRepositoryMock();
+        $pullRequestRepository = $this->getPullRequestRepositoryMock();
 
         $pullRequestRepository
             ->expects($this->once())
@@ -226,11 +226,11 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
                 $this->equalTo($startReference),
                 $this->equalTo($endReference)
             )
-            ->willReturn($this->rangeMock([]))
+            ->willReturn($this->getRangeMock([]))
         ;
 
         $command = new Console\PullRequestCommand(
-            $this->clientMock(),
+            $this->getClientMock(),
             $pullRequestRepository
         );
 
@@ -255,16 +255,16 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
 
         $expectedMessage = 'Could not find any pull requests';
 
-        $pullRequestRepository = $this->pullRequestRepositoryMock();
+        $pullRequestRepository = $this->getPullRequestRepositoryMock();
 
         $pullRequestRepository
             ->expects($this->any())
             ->method('items')
-            ->willReturn($this->rangeMock())
+            ->willReturn($this->getRangeMock())
         ;
 
         $command = new Console\PullRequestCommand(
-            $this->clientMock(),
+            $this->getClientMock(),
             $pullRequestRepository
         );
 
@@ -291,16 +291,16 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
 
         $expectedMessage = 'Could not find any pull requests';
 
-        $pullRequestRepository = $this->pullRequestRepositoryMock();
+        $pullRequestRepository = $this->getPullRequestRepositoryMock();
 
         $pullRequestRepository
             ->expects($this->any())
             ->method('items')
-            ->willReturn($this->rangeMock())
+            ->willReturn($this->getRangeMock())
         ;
 
         $command = new Console\PullRequestCommand(
-            $this->clientMock(),
+            $this->getClientMock(),
             $pullRequestRepository
         );
 
@@ -352,16 +352,16 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
             );
         });
 
-        $pullRequestRepository = $this->pullRequestRepositoryMock();
+        $pullRequestRepository = $this->getPullRequestRepositoryMock();
 
         $pullRequestRepository
             ->expects($this->any())
             ->method('items')
-            ->willReturn($this->rangeMock($pullRequests))
+            ->willReturn($this->getRangeMock($pullRequests))
         ;
 
         $command = new Console\PullRequestCommand(
-            $this->clientMock(),
+            $this->getClientMock(),
             $pullRequestRepository
         );
 
@@ -398,16 +398,16 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
             count($pullRequests)
         );
 
-        $pullRequestRepository = $this->pullRequestRepositoryMock();
+        $pullRequestRepository = $this->getPullRequestRepositoryMock();
 
         $pullRequestRepository
             ->expects($this->any())
             ->method('items')
-            ->willReturn($this->rangeMock($pullRequests))
+            ->willReturn($this->getRangeMock($pullRequests))
         ;
 
         $command = new Console\PullRequestCommand(
-            $this->clientMock(),
+            $this->getClientMock(),
             $pullRequestRepository
         );
 
@@ -430,7 +430,7 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
 
         $exception = new Exception('Wait, this should not happen!');
 
-        $pullRequestRepository = $this->pullRequestRepositoryMock();
+        $pullRequestRepository = $this->getPullRequestRepositoryMock();
 
         $pullRequestRepository
             ->expects($this->any())
@@ -444,7 +444,7 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
         );
 
         $command = new Console\PullRequestCommand(
-            $this->clientMock(),
+            $this->getClientMock(),
             $pullRequestRepository
         );
 
@@ -464,7 +464,7 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
     /**
      * @return PHPUnit_Framework_MockObject_MockObject|Client
      */
-    private function clientMock()
+    private function getClientMock()
     {
         return $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
@@ -475,7 +475,7 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
     /**
      * @return PHPUnit_Framework_MockObject_MockObject|Repository\PullRequestRepository
      */
-    private function pullRequestRepositoryMock()
+    private function getPullRequestRepositoryMock()
     {
         return $this->getMockBuilder(Repository\PullRequestRepository::class)
             ->disableOriginalConstructor()
@@ -488,7 +488,7 @@ class PullRequestCommandTest extends PHPUnit_Framework_TestCase
      *
      * @return PHPUnit_Framework_MockObject_MockObject|Resource\RangeInterface
      */
-    private function rangeMock(array $pullRequests = [])
+    private function getRangeMock(array $pullRequests = [])
     {
         $range = $this->getMockBuilder(Resource\RangeInterface::class)->getMock();
 

--- a/test/Repository/CommitRepositoryTest.php
+++ b/test/Repository/CommitRepositoryTest.php
@@ -29,7 +29,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         $repository = $faker->slug();
         $sha = $faker->sha1;
 
-        $commitApi = $this->commitApi();
+        $commitApi = $this->getCommitApiMock();
 
         $expectedItem = $this->commitItem();
 
@@ -66,7 +66,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         $repository = $faker->slug();
         $sha = $faker->sha1;
 
-        $api = $this->commitApi();
+        $api = $this->getCommitApiMock();
 
         $api
             ->expects($this->once())
@@ -98,7 +98,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         $repository = $faker->slug();
         $sha = $faker->sha1;
 
-        $commitApi = $this->commitApi();
+        $commitApi = $this->getCommitApiMock();
 
         $commitApi
             ->expects($this->once())
@@ -133,7 +133,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         $repository = $faker->slug();
         $sha = $faker->sha1;
 
-        $commitApi = $this->commitApi();
+        $commitApi = $this->getCommitApiMock();
 
         $expectedItems = $this->commitItems(15);
 
@@ -168,7 +168,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         $sha = $faker->sha1;
         $perPage = $faker->randomNumber();
 
-        $commitApi = $this->commitApi();
+        $commitApi = $this->getCommitApiMock();
 
         $expectedItems = $this->commitItems(15);
 
@@ -203,7 +203,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         $repository = $faker->slug();
         $sha = $faker->sha1;
 
-        $commitApi = $this->commitApi();
+        $commitApi = $this->getCommitApiMock();
 
         $expectedItems = $this->commitItems(15);
 
@@ -251,7 +251,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
 
         $endReference = $startReference;
 
-        $commitApi = $this->commitApi();
+        $commitApi = $this->getCommitApiMock();
 
         $commitApi
             ->expects($this->never())
@@ -279,7 +279,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitApi = $this->commitApi();
+        $commitApi = $this->getCommitApiMock();
 
         $commitApi
             ->expects($this->at(0))
@@ -318,7 +318,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitApi = $this->commitApi();
+        $commitApi = $this->getCommitApiMock();
 
         $commitApi
             ->expects($this->at(0))
@@ -368,7 +368,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitApi = $this->commitApi();
+        $commitApi = $this->getCommitApiMock();
 
         $startCommit = $this->commitItem();
 
@@ -424,7 +424,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         $repository = $faker->slug();
         $startReference = $faker->sha1;
 
-        $commitApi = $this->commitApi();
+        $commitApi = $this->getCommitApiMock();
 
         $startCommit = $this->commitItem();
 
@@ -467,7 +467,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitApi = $this->commitApi();
+        $commitApi = $this->getCommitApiMock();
 
         $startCommit = $this->commitItem();
         $startCommit->sha = $faker->sha1;
@@ -566,7 +566,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitApi = $this->commitApi();
+        $commitApi = $this->getCommitApiMock();
 
         $startCommit = $this->commitItem();
         $startCommit->sha = $faker->sha1;
@@ -684,7 +684,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
     /**
      * @return PHPUnit_Framework_MockObject_MockObject|Api\Repository\Commits
      */
-    private function commitApi()
+    private function getCommitApiMock()
     {
         return $this->getMockBuilder(Api\Repository\Commits::class)
             ->disableOriginalConstructor()

--- a/test/Repository/PullRequestRepositoryTest.php
+++ b/test/Repository/PullRequestRepositoryTest.php
@@ -28,7 +28,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
         $vendor = $faker->userName;
         $package = $faker->slug();
 
-        $api = $this->pullRequestApi();
+        $api = $this->getPullRequestApiMock();
 
         $expectedItem = $this->pullRequestItem();
 
@@ -45,7 +45,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
 
         $pullRequestRepository = new Repository\PullRequestRepository(
             $api,
-            $this->commitRepository()
+            $this->getCommitRepositoryMock()
         );
 
         $pullRequest = $pullRequestRepository->show(
@@ -68,7 +68,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
         $package = $faker->slug();
         $id = $faker->randomNumber();
 
-        $api = $this->pullRequestApi();
+        $api = $this->getPullRequestApiMock();
 
         $api
             ->expects($this->once())
@@ -83,7 +83,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
 
         $pullRequestRepository = new Repository\PullRequestRepository(
             $api,
-            $this->commitRepository()
+            $this->getCommitRepositoryMock()
         );
 
         $pullRequest = $pullRequestRepository->show(
@@ -103,9 +103,9 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
         $package = $faker->slug();
         $startReference = $faker->sha1;
 
-        $commitRepository = $this->commitRepository();
+        $commitRepository = $this->getCommitRepositoryMock();
 
-        $range = $this->rangeMock();
+        $range = $this->getRangeMock();
 
         $range
             ->expects($this->any())
@@ -126,7 +126,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
         ;
 
         $repository = new Repository\PullRequestRepository(
-            $this->pullRequestApi(),
+            $this->getPullRequestApiMock(),
             $commitRepository
         );
 
@@ -146,7 +146,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $range = $this->rangeMock();
+        $range = $this->getRangeMock();
 
         $range
             ->expects($this->any())
@@ -159,7 +159,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
             ->method('withPullRequest')
         ;
 
-        $commitRepository = $this->commitRepository();
+        $commitRepository = $this->getCommitRepositoryMock();
 
         $commitRepository
             ->expects($this->once())
@@ -174,7 +174,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
         ;
 
         $repository = new Repository\PullRequestRepository(
-            $this->pullRequestApi(),
+            $this->getPullRequestApiMock(),
             $commitRepository
         );
 
@@ -195,14 +195,14 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitRepository = $this->commitRepository();
+        $commitRepository = $this->getCommitRepositoryMock();
 
         $commit = new Resource\Commit(
             $faker->sha1,
             'I am not a merge commit'
         );
 
-        $range = $this->rangeMock();
+        $range = $this->getRangeMock();
 
         $range
             ->expects($this->any())
@@ -230,7 +230,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
         ;
 
         $repository = new Repository\PullRequestRepository(
-            $this->pullRequestApi(),
+            $this->getPullRequestApiMock(),
             $commitRepository
         );
 
@@ -251,7 +251,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitRepository = $this->commitRepository();
+        $commitRepository = $this->getCommitRepositoryMock();
 
         $expectedItem = $this->pullRequestItem();
 
@@ -263,9 +263,9 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
             )
         );
 
-        $mutatedRange = $this->rangeMock();
+        $mutatedRange = $this->getRangeMock();
 
-        $range = $this->rangeMock();
+        $range = $this->getRangeMock();
 
         $range
             ->expects($this->any())
@@ -294,7 +294,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
             ->willReturn($range)
         ;
 
-        $api = $this->pullRequestApi();
+        $api = $this->getPullRequestApiMock();
 
         $api
             ->expects($this->once())
@@ -331,7 +331,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitRepository = $this->commitRepository();
+        $commitRepository = $this->getCommitRepositoryMock();
 
         $id = 9000;
 
@@ -343,7 +343,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
             )
         );
 
-        $range = $this->rangeMock();
+        $range = $this->getRangeMock();
 
         $range
             ->expects($this->any())
@@ -370,7 +370,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
             ->willReturn($range)
         ;
 
-        $pullRequestApi = $this->pullRequestApi();
+        $pullRequestApi = $this->getPullRequestApiMock();
 
         $pullRequestApi
             ->expects($this->once())
@@ -399,7 +399,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
     /**
      * @return PHPUnit_Framework_MockObject_MockObject|Api\PullRequest
      */
-    private function pullRequestApi()
+    private function getPullRequestApiMock()
     {
         return $this->getMockBuilder(Api\PullRequest::class)
             ->disableOriginalConstructor()
@@ -410,7 +410,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
     /**
      * @return PHPUnit_Framework_MockObject_MockObject|Repository\CommitRepository
      */
-    private function commitRepository()
+    private function getCommitRepositoryMock()
     {
         return $this->getMockBuilder(Repository\CommitRepository::class)
             ->disableOriginalConstructor()
@@ -421,7 +421,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
     /**
      * @return PHPUnit_Framework_MockObject_MockObject|Resource\RangeInterface
      */
-    private function rangeMock()
+    private function getRangeMock()
     {
         return $this->getMockBuilder(Resource\RangeInterface::class)->getMock();
     }

--- a/test/Resource/RangeTest.php
+++ b/test/Resource/RangeTest.php
@@ -44,7 +44,7 @@ class RangeTest extends PHPUnit_Framework_TestCase
 
     public function testWithCommitClonesRangeAndAddsCommit()
     {
-        $commit = $this->commitMock();
+        $commit = $this->getCommitMock();
 
         $range = new Range();
 
@@ -59,7 +59,7 @@ class RangeTest extends PHPUnit_Framework_TestCase
 
     public function testWithPullRequestClonesRangeAndAddsPullRequest()
     {
-        $pullRequest = $this->pullRequestMock();
+        $pullRequest = $this->getPullRequestMock();
 
         $range = new Range();
 
@@ -75,7 +75,7 @@ class RangeTest extends PHPUnit_Framework_TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|CommitInterface
      */
-    private function commitMock()
+    private function getCommitMock()
     {
         return $this->getMockBuilder(CommitInterface::class)->getMock();
     }
@@ -83,7 +83,7 @@ class RangeTest extends PHPUnit_Framework_TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|PullRequestInterface
      */
-    private function pullRequestMock()
+    private function getPullRequestMock()
     {
         return $this->getMockBuilder(PullRequestInterface::class)->getMock();
     }


### PR DESCRIPTION
This PR

* [x] renames methods returning mocks