### PR TITLE
Fix: Drop PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.5
     - php: 5.6
       env: WITH_CS=true
     - php: 7

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "beberlei/assert": "^2.4",
         "codeclimate/php-test-reporter": "0.2.0",
         "knplabs/github-api": "^1.4.14",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "214dbc09b911f259f0c84e86426ec6a7",
-    "content-hash": "bd74092f64f642492a678f8009526678",
+    "hash": "cd49858e584c477aeb8bebdb64fc9e01",
+    "content-hash": "e573e4799a0670586b49309e984617e7",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -211,6 +211,7 @@
                 "rest",
                 "web service"
             ],
+            "abandoned": "guzzlehttp/guzzle",
             "time": "2015-03-18 18:23:50"
         },
         {
@@ -1976,7 +1977,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.5 || ^7.0"
+        "php": "^5.6 || ^7.0"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
This PR

* [x] drops PHP 5.5 support and removes it from the build matrix