### PR TITLE
Enhancement: Keep packages sorted without specifying --sort-packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
     "license": "MIT",
     "minimum-stability": "dev",
     "prefer-stable": true,
+    "config": {
+        "sort-packages": true
+    },
     "require": {
         "php": "^5.6 || ^7.0",
         "beberlei/assert": "^2.6.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "9a620f6efced90a7e9a634e9000672e6",
+    "hash": "8f89daeb318f49cb0829a4bf5436f941",
     "content-hash": "26d7d63d414540918cd43e3e4f015688",
     "packages": [
         {


### PR DESCRIPTION
This PR

* [x] keeps packages in `composer.json` sorted without having to specify `--sort-packages` when requiring packages
