### PR TITLE
Fix: Use TestHelper instead of deprecated GeneratorTrait

### DIFF
--- a/test/Console/GenerateCommandTest.php
+++ b/test/Console/GenerateCommandTest.php
@@ -17,14 +17,14 @@ use Localheinz\GitHub\ChangeLog\Repository;
 use Localheinz\GitHub\ChangeLog\Resource;
 use PHPUnit_Framework_MockObject_MockObject;
 use PHPUnit_Framework_TestCase;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 use ReflectionProperty;
 use Symfony\Component\Console\Input;
 use Symfony\Component\Console\Tester\CommandTester;
 
 class GenerateCommandTest extends PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testHasName()
     {

--- a/test/Repository/CommitRepositoryTest.php
+++ b/test/Repository/CommitRepositoryTest.php
@@ -14,12 +14,12 @@ use Localheinz\GitHub\ChangeLog\Repository;
 use Localheinz\GitHub\ChangeLog\Resource;
 use PHPUnit_Framework_MockObject_MockObject;
 use PHPUnit_Framework_TestCase;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 use stdClass;
 
 class CommitRepositoryTest extends PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testShowReturnsCommitEntityWithShaAndMessageOnSuccess()
     {

--- a/test/Repository/PullRequestRepositoryTest.php
+++ b/test/Repository/PullRequestRepositoryTest.php
@@ -14,12 +14,12 @@ use Localheinz\GitHub\ChangeLog\Repository;
 use Localheinz\GitHub\ChangeLog\Resource;
 use PHPUnit_Framework_MockObject_MockObject;
 use PHPUnit_Framework_TestCase;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 use stdClass;
 
 class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testShowReturnsPullRequestEntityWithIdAndTitleOnSuccess()
     {

--- a/test/Resource/AuthorTest.php
+++ b/test/Resource/AuthorTest.php
@@ -14,11 +14,11 @@ use Localheinz\GitHub\ChangeLog\Resource;
 use Localheinz\GitHub\ChangeLog\Resource\Author;
 use Localheinz\GitHub\ChangeLog\Resource\AuthorInterface;
 use PHPUnit_Framework_TestCase;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class AuthorTest extends PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testIsFinal()
     {

--- a/test/Resource/CommitTest.php
+++ b/test/Resource/CommitTest.php
@@ -14,11 +14,11 @@ use Localheinz\GitHub\ChangeLog\Resource;
 use Localheinz\GitHub\ChangeLog\Resource\Commit;
 use Localheinz\GitHub\ChangeLog\Resource\CommitInterface;
 use PHPUnit_Framework_TestCase;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class CommitTest extends PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testIsFinal()
     {

--- a/test/Resource/PullRequestTest.php
+++ b/test/Resource/PullRequestTest.php
@@ -14,11 +14,11 @@ use Localheinz\GitHub\ChangeLog\Resource;
 use Localheinz\GitHub\ChangeLog\Resource\PullRequest;
 use Localheinz\GitHub\ChangeLog\Resource\PullRequestInterface;
 use PHPUnit_Framework_TestCase;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class PullRequestTest extends PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testIsFinal()
     {

--- a/test/Resource/RangeTest.php
+++ b/test/Resource/RangeTest.php
@@ -14,11 +14,11 @@ use Localheinz\GitHub\ChangeLog\Resource\PullRequestInterface;
 use Localheinz\GitHub\ChangeLog\Resource\Range;
 use Localheinz\GitHub\ChangeLog\Resource\RangeInterface;
 use PHPUnit_Framework_TestCase;
-use Refinery29\Test\Util\Faker\GeneratorTrait;
+use Refinery29\Test\Util\TestHelper;
 
 class RangeTest extends PHPUnit_Framework_TestCase
 {
-    use GeneratorTrait;
+    use TestHelper;
 
     public function testIsFinal()
     {


### PR DESCRIPTION
This PR

* [x] uses `TestHelper` instead of the deprecated `GeneratorTrait`

Follows #120.
