### PR TITLE
Fix: Use expectException() instead of deprecated setExpectedException()

### DIFF
--- a/test/Resource/AuthorTest.php
+++ b/test/Resource/AuthorTest.php
@@ -41,7 +41,7 @@ class AuthorTest extends PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidLogin($login)
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $htmlUrl = $this->getFaker()->url;
 
@@ -77,7 +77,7 @@ class AuthorTest extends PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidHtmlUrl($htmlUrl)
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $login = $this->getFaker()->userName;
 

--- a/test/Resource/CommitTest.php
+++ b/test/Resource/CommitTest.php
@@ -41,7 +41,7 @@ class CommitTest extends PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidSha($sha)
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $message = $this->getFaker()->sentence();
 
@@ -81,7 +81,7 @@ class CommitTest extends PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidMessage($message)
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $sha = $this->getFaker()->sha1;
 

--- a/test/Resource/PullRequestTest.php
+++ b/test/Resource/PullRequestTest.php
@@ -41,7 +41,7 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidId($id)
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $title = $this->getFaker()->sentence();
 
@@ -82,7 +82,7 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidTitle($message)
     {
-        $this->setExpectedException(InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $sha = sha1($this->getFaker()->sentence());
 


### PR DESCRIPTION
This PR

* [x] uses `expectException()` instead of deprecated `setExpectedException()`

Follows #119.

