### PR TITLE
Fix: Do not import every class

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -9,7 +9,6 @@
 
 namespace Localheinz\GitHub\ChangeLog\Console;
 
-use Exception;
 use Github\Api;
 use Github\Client;
 use Github\HttpClient;
@@ -135,7 +134,7 @@ class GenerateCommand extends Command
                 $startReference,
                 $endReference
             );
-        } catch (Exception $exception) {
+        } catch (\Exception $exception) {
             $io->error(sprintf(
                 'An error occurred: %s',
                 $exception->getMessage()

--- a/test/Console/GenerateCommandTest.php
+++ b/test/Console/GenerateCommandTest.php
@@ -9,20 +9,17 @@
 
 namespace Localheinz\GitHub\ChangeLog\Test\Console;
 
-use Exception;
 use Github\Client;
 use Github\HttpClient;
 use Localheinz\GitHub\ChangeLog\Console;
 use Localheinz\GitHub\ChangeLog\Repository;
 use Localheinz\GitHub\ChangeLog\Resource;
-use PHPUnit_Framework_MockObject_MockObject;
-use PHPUnit_Framework_TestCase;
 use Refinery29\Test\Util\TestHelper;
 use ReflectionProperty;
 use Symfony\Component\Console\Input;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class GenerateCommandTest extends PHPUnit_Framework_TestCase
+class GenerateCommandTest extends \PHPUnit_Framework_TestCase
 {
     use TestHelper;
 
@@ -421,7 +418,7 @@ class GenerateCommandTest extends PHPUnit_Framework_TestCase
     {
         $faker = $this->getFaker();
 
-        $exception = new Exception('Wait, this should not happen!');
+        $exception = new \Exception('Wait, this should not happen!');
 
         $pullRequestRepository = $this->getPullRequestRepositoryMock();
 
@@ -454,7 +451,7 @@ class GenerateCommandTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return PHPUnit_Framework_MockObject_MockObject|Client
+     * @return \PHPUnit_Framework_MockObject_MockObject|Client
      */
     private function getClientMock()
     {
@@ -462,7 +459,7 @@ class GenerateCommandTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return PHPUnit_Framework_MockObject_MockObject|Repository\PullRequestRepository
+     * @return \PHPUnit_Framework_MockObject_MockObject|Repository\PullRequestRepository
      */
     private function getPullRequestRepositoryMock()
     {
@@ -472,7 +469,7 @@ class GenerateCommandTest extends PHPUnit_Framework_TestCase
     /**
      * @param array $pullRequests
      *
-     * @return PHPUnit_Framework_MockObject_MockObject|Resource\RangeInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|Resource\RangeInterface
      */
     private function getRangeMock(array $pullRequests = [])
     {

--- a/test/Repository/CommitRepositoryTest.php
+++ b/test/Repository/CommitRepositoryTest.php
@@ -12,12 +12,9 @@ namespace Localheinz\GitHub\ChangeLog\Test\Repository;
 use Github\Api;
 use Localheinz\GitHub\ChangeLog\Repository;
 use Localheinz\GitHub\ChangeLog\Resource;
-use PHPUnit_Framework_MockObject_MockObject;
-use PHPUnit_Framework_TestCase;
 use Refinery29\Test\Util\TestHelper;
-use stdClass;
 
-class CommitRepositoryTest extends PHPUnit_Framework_TestCase
+class CommitRepositoryTest extends \PHPUnit_Framework_TestCase
 {
     use TestHelper;
 
@@ -658,7 +655,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return PHPUnit_Framework_MockObject_MockObject|Api\Repository\Commits
+     * @return \PHPUnit_Framework_MockObject_MockObject|Api\Repository\Commits
      */
     private function getCommitApiMock()
     {
@@ -669,11 +666,11 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
      * @param string $sha
      * @param string $message
      *
-     * @return stdClass
+     * @return \stdClass
      */
     private function commitItem($sha = null, $message = null)
     {
-        $data = new stdClass();
+        $data = new \stdClass();
 
         $data->sha = $sha ?: $this->getFaker()->unique()->sha1;
         $data->message = $message ?: $this->getFaker()->unique()->sentence();
@@ -684,7 +681,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
     /**
      * @param int $count
      *
-     * @return stdClass[]
+     * @return \stdClass[]
      */
     private function commitItems($count)
     {
@@ -698,11 +695,11 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param stdClass $item
+     * @param \stdClass $item
      *
      * @return array
      */
-    private function response(stdClass $item)
+    private function response(\stdClass $item)
     {
         $template = file_get_contents(__DIR__ . '/_response/commit.json');
 

--- a/test/Repository/PullRequestRepositoryTest.php
+++ b/test/Repository/PullRequestRepositoryTest.php
@@ -12,12 +12,9 @@ namespace Localheinz\GitHub\ChangeLog\Test\Repository;
 use Github\Api;
 use Localheinz\GitHub\ChangeLog\Repository;
 use Localheinz\GitHub\ChangeLog\Resource;
-use PHPUnit_Framework_MockObject_MockObject;
-use PHPUnit_Framework_TestCase;
 use Refinery29\Test\Util\TestHelper;
-use stdClass;
 
-class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
+class PullRequestRepositoryTest extends \PHPUnit_Framework_TestCase
 {
     use TestHelper;
 
@@ -379,7 +376,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return PHPUnit_Framework_MockObject_MockObject|Api\PullRequest
+     * @return \PHPUnit_Framework_MockObject_MockObject|Api\PullRequest
      */
     private function getPullRequestApiMock()
     {
@@ -387,7 +384,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return PHPUnit_Framework_MockObject_MockObject|Repository\CommitRepository
+     * @return \PHPUnit_Framework_MockObject_MockObject|Repository\CommitRepository
      */
     private function getCommitRepositoryMock()
     {
@@ -395,7 +392,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return PHPUnit_Framework_MockObject_MockObject|Resource\RangeInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|Resource\RangeInterface
      */
     private function getRangeMock()
     {
@@ -403,11 +400,11 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return stdClass
+     * @return \stdClass
      */
     private function pullRequestItem()
     {
-        $item = new stdClass();
+        $item = new \stdClass();
 
         $item->id = $this->getFaker()->unique()->randomNumber();
         $item->title = $this->getFaker()->unique()->sentence();
@@ -416,11 +413,11 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param stdClass $item
+     * @param \stdClass $item
      *
      * @return array
      */
-    private function response(stdClass $item)
+    private function response(\stdClass $item)
     {
         $template = file_get_contents(__DIR__ . '/_response/pull-request.json');
 

--- a/test/Resource/AuthorTest.php
+++ b/test/Resource/AuthorTest.php
@@ -9,29 +9,25 @@
 
 namespace Localheinz\GitHub\ChangeLog\Test\Resource;
 
-use InvalidArgumentException;
 use Localheinz\GitHub\ChangeLog\Resource;
-use Localheinz\GitHub\ChangeLog\Resource\Author;
-use Localheinz\GitHub\ChangeLog\Resource\AuthorInterface;
-use PHPUnit_Framework_TestCase;
 use Refinery29\Test\Util\TestHelper;
 
-class AuthorTest extends PHPUnit_Framework_TestCase
+class AuthorTest extends \PHPUnit_Framework_TestCase
 {
     use TestHelper;
 
     public function testIsFinal()
     {
-        $reflectionClass = new \ReflectionClass(Author::class);
+        $reflectionClass = new \ReflectionClass(Resource\Author::class);
 
         $this->assertTrue($reflectionClass->isFinal());
     }
 
     public function testImplementsAuthorInterface()
     {
-        $reflectionClass = new \ReflectionClass(Author::class);
+        $reflectionClass = new \ReflectionClass(Resource\Author::class);
 
-        $this->assertTrue($reflectionClass->implementsInterface(AuthorInterface::class));
+        $this->assertTrue($reflectionClass->implementsInterface(Resource\AuthorInterface::class));
     }
 
     /**
@@ -41,7 +37,7 @@ class AuthorTest extends PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidLogin($login)
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $htmlUrl = $this->getFaker()->url;
 
@@ -58,7 +54,7 @@ class AuthorTest extends PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidHtmlUrl($htmlUrl)
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $login = $this->getFaker()->userName;
 

--- a/test/Resource/CommitTest.php
+++ b/test/Resource/CommitTest.php
@@ -9,30 +9,26 @@
 
 namespace Localheinz\GitHub\ChangeLog\Test\Resource;
 
-use InvalidArgumentException;
 use Localheinz\GitHub\ChangeLog\Resource;
-use Localheinz\GitHub\ChangeLog\Resource\Commit;
-use Localheinz\GitHub\ChangeLog\Resource\CommitInterface;
-use PHPUnit_Framework_TestCase;
 use Refinery29\Test\Util\DataProvider;
 use Refinery29\Test\Util\TestHelper;
 
-class CommitTest extends PHPUnit_Framework_TestCase
+class CommitTest extends \PHPUnit_Framework_TestCase
 {
     use TestHelper;
 
     public function testIsFinal()
     {
-        $reflectionClass = new \ReflectionClass(Commit::class);
+        $reflectionClass = new \ReflectionClass(Resource\Commit::class);
 
         $this->assertTrue($reflectionClass->isFinal());
     }
 
     public function testImplementsCommitInterface()
     {
-        $reflectionClass = new \ReflectionClass(Commit::class);
+        $reflectionClass = new \ReflectionClass(Resource\Commit::class);
 
-        $this->assertTrue($reflectionClass->implementsInterface(CommitInterface::class));
+        $this->assertTrue($reflectionClass->implementsInterface(Resource\CommitInterface::class));
     }
 
     /**
@@ -42,7 +38,7 @@ class CommitTest extends PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidSha($sha)
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $message = $this->getFaker()->sentence();
 
@@ -76,7 +72,7 @@ class CommitTest extends PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidMessage($message)
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $sha = $this->getFaker()->sha1;
 

--- a/test/Resource/PullRequestTest.php
+++ b/test/Resource/PullRequestTest.php
@@ -9,30 +9,26 @@
 
 namespace Localheinz\GitHub\ChangeLog\Test\Resource;
 
-use InvalidArgumentException;
 use Localheinz\GitHub\ChangeLog\Resource;
-use Localheinz\GitHub\ChangeLog\Resource\PullRequest;
-use Localheinz\GitHub\ChangeLog\Resource\PullRequestInterface;
-use PHPUnit_Framework_TestCase;
 use Refinery29\Test\Util\DataProvider;
 use Refinery29\Test\Util\TestHelper;
 
-class PullRequestTest extends PHPUnit_Framework_TestCase
+class PullRequestTest extends \PHPUnit_Framework_TestCase
 {
     use TestHelper;
 
     public function testIsFinal()
     {
-        $reflectionClass = new \ReflectionClass(PullRequest::class);
+        $reflectionClass = new \ReflectionClass(Resource\PullRequest::class);
 
         $this->assertTrue($reflectionClass->isFinal());
     }
 
     public function testImplementsPullRequestInterface()
     {
-        $reflectionClass = new \ReflectionClass(PullRequest::class);
+        $reflectionClass = new \ReflectionClass(Resource\PullRequest::class);
 
-        $this->assertTrue($reflectionClass->implementsInterface(PullRequestInterface::class));
+        $this->assertTrue($reflectionClass->implementsInterface(Resource\PullRequestInterface::class));
     }
 
     /**
@@ -42,7 +38,7 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidId($id)
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $title = $this->getFaker()->sentence();
 
@@ -73,7 +69,7 @@ class PullRequestTest extends PHPUnit_Framework_TestCase
      */
     public function testConstructorRejectsInvalidTitle($message)
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $sha = sha1($this->getFaker()->sentence());
 

--- a/test/Resource/RangeTest.php
+++ b/test/Resource/RangeTest.php
@@ -9,34 +9,30 @@
 
 namespace Localheinz\GitHub\ChangeLog\Test\Resource;
 
-use Localheinz\GitHub\ChangeLog\Resource\CommitInterface;
-use Localheinz\GitHub\ChangeLog\Resource\PullRequestInterface;
-use Localheinz\GitHub\ChangeLog\Resource\Range;
-use Localheinz\GitHub\ChangeLog\Resource\RangeInterface;
-use PHPUnit_Framework_TestCase;
+use Localheinz\GitHub\ChangeLog\Resource;
 use Refinery29\Test\Util\TestHelper;
 
-class RangeTest extends PHPUnit_Framework_TestCase
+class RangeTest extends \PHPUnit_Framework_TestCase
 {
     use TestHelper;
 
     public function testIsFinal()
     {
-        $reflectionClass = new \ReflectionClass(Range::class);
+        $reflectionClass = new \ReflectionClass(Resource\Range::class);
 
         $this->assertTrue($reflectionClass->isFinal());
     }
 
     public function testImplementsRangeInterface()
     {
-        $reflectionClass = new \ReflectionClass(Range::class);
+        $reflectionClass = new \ReflectionClass(Resource\Range::class);
 
-        $this->assertTrue($reflectionClass->implementsInterface(RangeInterface::class));
+        $this->assertTrue($reflectionClass->implementsInterface(Resource\RangeInterface::class));
     }
 
     public function testDefaults()
     {
-        $range = new Range();
+        $range = new Resource\Range();
 
         $this->assertSame([], $range->commits());
         $this->assertSame([], $range->pullRequests());
@@ -46,11 +42,11 @@ class RangeTest extends PHPUnit_Framework_TestCase
     {
         $commit = $this->getCommitMock();
 
-        $range = new Range();
+        $range = new Resource\Range();
 
         $mutated = $range->withCommit($commit);
 
-        $this->assertInstanceOf(Range::class, $mutated);
+        $this->assertInstanceOf(Resource\Range::class, $mutated);
         $this->assertNotSame($range, $mutated);
         $this->assertCount(0, $range->commits());
         $this->assertCount(1, $mutated->commits());
@@ -61,11 +57,11 @@ class RangeTest extends PHPUnit_Framework_TestCase
     {
         $pullRequest = $this->getPullRequestMock();
 
-        $range = new Range();
+        $range = new Resource\Range();
 
         $mutated = $range->withPullRequest($pullRequest);
 
-        $this->assertInstanceOf(Range::class, $mutated);
+        $this->assertInstanceOf(Resource\Range::class, $mutated);
         $this->assertNotSame($range, $mutated);
         $this->assertCount(0, $range->pullRequests());
         $this->assertCount(1, $mutated->pullRequests());
@@ -73,18 +69,18 @@ class RangeTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|CommitInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|Resource\CommitInterface
      */
     private function getCommitMock()
     {
-        return $this->createMock(CommitInterface::class);
+        return $this->createMock(Resource\CommitInterface::class);
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|PullRequestInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|Resource\PullRequestInterface
      */
     private function getPullRequestMock()
     {
-        return $this->createMock(PullRequestInterface::class);
+        return $this->createMock(Resource\PullRequestInterface::class);
     }
 }


### PR DESCRIPTION
This PR

* [x] removes a bunch of imports (classes from the root namespace), and also imports parent namespaces only
