### PR TITLE
Fix: Use createMock()

### DIFF
--- a/test/Console/GenerateCommandTest.php
+++ b/test/Console/GenerateCommandTest.php
@@ -458,9 +458,7 @@ class GenerateCommandTest extends PHPUnit_Framework_TestCase
      */
     private function getClientMock()
     {
-        return $this->getMockBuilder(Client::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(Client::class);
     }
 
     /**
@@ -468,9 +466,7 @@ class GenerateCommandTest extends PHPUnit_Framework_TestCase
      */
     private function getPullRequestRepositoryMock()
     {
-        return $this->getMockBuilder(Repository\PullRequestRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(Repository\PullRequestRepository::class);
     }
 
     /**
@@ -480,7 +476,7 @@ class GenerateCommandTest extends PHPUnit_Framework_TestCase
      */
     private function getRangeMock(array $pullRequests = [])
     {
-        $range = $this->getMockBuilder(Resource\RangeInterface::class)->getMock();
+        $range = $this->createMock(Resource\RangeInterface::class);
 
         $range
             ->expects($this->any())

--- a/test/Repository/CommitRepositoryTest.php
+++ b/test/Repository/CommitRepositoryTest.php
@@ -662,9 +662,7 @@ class CommitRepositoryTest extends PHPUnit_Framework_TestCase
      */
     private function getCommitApiMock()
     {
-        return $this->getMockBuilder(Api\Repository\Commits::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(Api\Repository\Commits::class);
     }
 
     /**

--- a/test/Repository/PullRequestRepositoryTest.php
+++ b/test/Repository/PullRequestRepositoryTest.php
@@ -383,9 +383,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
      */
     private function getPullRequestApiMock()
     {
-        return $this->getMockBuilder(Api\PullRequest::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(Api\PullRequest::class);
     }
 
     /**
@@ -393,9 +391,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
      */
     private function getCommitRepositoryMock()
     {
-        return $this->getMockBuilder(Repository\CommitRepository::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(Repository\CommitRepository::class);
     }
 
     /**
@@ -403,7 +399,7 @@ class PullRequestRepositoryTest extends PHPUnit_Framework_TestCase
      */
     private function getRangeMock()
     {
-        return $this->getMockBuilder(Resource\RangeInterface::class)->getMock();
+        return $this->createMock(Resource\RangeInterface::class);
     }
 
     /**

--- a/test/Resource/RangeTest.php
+++ b/test/Resource/RangeTest.php
@@ -77,7 +77,7 @@ class RangeTest extends PHPUnit_Framework_TestCase
      */
     private function getCommitMock()
     {
-        return $this->getMockBuilder(CommitInterface::class)->getMock();
+        return $this->createMock(CommitInterface::class);
     }
 
     /**
@@ -85,6 +85,6 @@ class RangeTest extends PHPUnit_Framework_TestCase
      */
     private function getPullRequestMock()
     {
-        return $this->getMockBuilder(PullRequestInterface::class)->getMock();
+        return $this->createMock(PullRequestInterface::class);
     }
 }


### PR DESCRIPTION
This PR

* [x] use `createMock()` where appropriate

Follows #119.
