### PR TITLE
Fix: Do not fetch faker more often than once

### DIFF
--- a/test/Repository/CommitRepositoryTest.php
+++ b/test/Repository/CommitRepositoryTest.php
@@ -670,10 +670,12 @@ class CommitRepositoryTest extends \PHPUnit_Framework_TestCase
      */
     private function commitItem($sha = null, $message = null)
     {
+        $faker = $this->getFaker();
+
         $data = new \stdClass();
 
-        $data->sha = $sha ?: $this->getFaker()->unique()->sha1;
-        $data->message = $message ?: $this->getFaker()->unique()->sentence();
+        $data->sha = $sha ?: $faker->unique()->sha1;
+        $data->message = $message ?: $faker->unique()->sentence();
 
         return $data;
     }

--- a/test/Repository/PullRequestRepositoryTest.php
+++ b/test/Repository/PullRequestRepositoryTest.php
@@ -243,7 +243,7 @@ class PullRequestRepositoryTest extends \PHPUnit_Framework_TestCase
         $expectedItem = $this->pullRequestItem();
 
         $mergeCommit = new Resource\Commit(
-            $this->getFaker()->unique()->sha1,
+            $faker->unique()->sha1,
             sprintf(
                 'Merge pull request #%s from localheinz/fix/directory',
                 $expectedItem->id
@@ -404,10 +404,12 @@ class PullRequestRepositoryTest extends \PHPUnit_Framework_TestCase
      */
     private function pullRequestItem()
     {
+        $faker = $this->getFaker();
+
         $item = new \stdClass();
 
-        $item->id = $this->getFaker()->unique()->randomNumber();
-        $item->title = $this->getFaker()->unique()->sentence();
+        $item->id = $faker->unique()->randomNumber();
+        $item->title = $faker->unique()->sentence();
 
         return $item;
     }


### PR DESCRIPTION
This PR

* [x] ensures that we fetch the faker generator once only 

