### PR TITLE
Fix: Mark all tests as final

### DIFF
--- a/test/Console/GenerateCommandTest.php
+++ b/test/Console/GenerateCommandTest.php
@@ -19,7 +19,7 @@ use ReflectionProperty;
 use Symfony\Component\Console\Input;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class GenerateCommandTest extends \PHPUnit_Framework_TestCase
+final class GenerateCommandTest extends \PHPUnit_Framework_TestCase
 {
     use TestHelper;
 

--- a/test/Repository/CommitRepositoryTest.php
+++ b/test/Repository/CommitRepositoryTest.php
@@ -14,7 +14,7 @@ use Localheinz\GitHub\ChangeLog\Repository;
 use Localheinz\GitHub\ChangeLog\Resource;
 use Refinery29\Test\Util\TestHelper;
 
-class CommitRepositoryTest extends \PHPUnit_Framework_TestCase
+final class CommitRepositoryTest extends \PHPUnit_Framework_TestCase
 {
     use TestHelper;
 

--- a/test/Repository/PullRequestRepositoryTest.php
+++ b/test/Repository/PullRequestRepositoryTest.php
@@ -14,7 +14,7 @@ use Localheinz\GitHub\ChangeLog\Repository;
 use Localheinz\GitHub\ChangeLog\Resource;
 use Refinery29\Test\Util\TestHelper;
 
-class PullRequestRepositoryTest extends \PHPUnit_Framework_TestCase
+final class PullRequestRepositoryTest extends \PHPUnit_Framework_TestCase
 {
     use TestHelper;
 

--- a/test/Resource/AuthorTest.php
+++ b/test/Resource/AuthorTest.php
@@ -12,7 +12,7 @@ namespace Localheinz\GitHub\ChangeLog\Test\Resource;
 use Localheinz\GitHub\ChangeLog\Resource;
 use Refinery29\Test\Util\TestHelper;
 
-class AuthorTest extends \PHPUnit_Framework_TestCase
+final class AuthorTest extends \PHPUnit_Framework_TestCase
 {
     use TestHelper;
 

--- a/test/Resource/CommitTest.php
+++ b/test/Resource/CommitTest.php
@@ -13,7 +13,7 @@ use Localheinz\GitHub\ChangeLog\Resource;
 use Refinery29\Test\Util\DataProvider;
 use Refinery29\Test\Util\TestHelper;
 
-class CommitTest extends \PHPUnit_Framework_TestCase
+final class CommitTest extends \PHPUnit_Framework_TestCase
 {
     use TestHelper;
 

--- a/test/Resource/PullRequestTest.php
+++ b/test/Resource/PullRequestTest.php
@@ -13,7 +13,7 @@ use Localheinz\GitHub\ChangeLog\Resource;
 use Refinery29\Test\Util\DataProvider;
 use Refinery29\Test\Util\TestHelper;
 
-class PullRequestTest extends \PHPUnit_Framework_TestCase
+final class PullRequestTest extends \PHPUnit_Framework_TestCase
 {
     use TestHelper;
 

--- a/test/Resource/RangeTest.php
+++ b/test/Resource/RangeTest.php
@@ -12,7 +12,7 @@ namespace Localheinz\GitHub\ChangeLog\Test\Resource;
 use Localheinz\GitHub\ChangeLog\Resource;
 use Refinery29\Test\Util\TestHelper;
 
-class RangeTest extends \PHPUnit_Framework_TestCase
+final class RangeTest extends \PHPUnit_Framework_TestCase
 {
     use TestHelper;
 


### PR DESCRIPTION
This PR

* [x] marks all tests as `final`

💁‍♂️ There really is no need to extend them.
