### PR TITLE
Fix: Use shorter variable name

### DIFF
--- a/test/Resource/AuthorTest.php
+++ b/test/Resource/AuthorTest.php
@@ -18,16 +18,16 @@ final class AuthorTest extends \PHPUnit_Framework_TestCase
 
     public function testIsFinal()
     {
-        $reflectionClass = new \ReflectionClass(Resource\Author::class);
+        $reflection = new \ReflectionClass(Resource\Author::class);
 
-        $this->assertTrue($reflectionClass->isFinal());
+        $this->assertTrue($reflection->isFinal());
     }
 
     public function testImplementsAuthorInterface()
     {
-        $reflectionClass = new \ReflectionClass(Resource\Author::class);
+        $reflection = new \ReflectionClass(Resource\Author::class);
 
-        $this->assertTrue($reflectionClass->implementsInterface(Resource\AuthorInterface::class));
+        $this->assertTrue($reflection->implementsInterface(Resource\AuthorInterface::class));
     }
 
     /**

--- a/test/Resource/CommitTest.php
+++ b/test/Resource/CommitTest.php
@@ -19,16 +19,16 @@ final class CommitTest extends \PHPUnit_Framework_TestCase
 
     public function testIsFinal()
     {
-        $reflectionClass = new \ReflectionClass(Resource\Commit::class);
+        $reflection = new \ReflectionClass(Resource\Commit::class);
 
-        $this->assertTrue($reflectionClass->isFinal());
+        $this->assertTrue($reflection->isFinal());
     }
 
     public function testImplementsCommitInterface()
     {
-        $reflectionClass = new \ReflectionClass(Resource\Commit::class);
+        $reflection = new \ReflectionClass(Resource\Commit::class);
 
-        $this->assertTrue($reflectionClass->implementsInterface(Resource\CommitInterface::class));
+        $this->assertTrue($reflection->implementsInterface(Resource\CommitInterface::class));
     }
 
     /**

--- a/test/Resource/PullRequestTest.php
+++ b/test/Resource/PullRequestTest.php
@@ -19,16 +19,16 @@ final class PullRequestTest extends \PHPUnit_Framework_TestCase
 
     public function testIsFinal()
     {
-        $reflectionClass = new \ReflectionClass(Resource\PullRequest::class);
+        $reflection = new \ReflectionClass(Resource\PullRequest::class);
 
-        $this->assertTrue($reflectionClass->isFinal());
+        $this->assertTrue($reflection->isFinal());
     }
 
     public function testImplementsPullRequestInterface()
     {
-        $reflectionClass = new \ReflectionClass(Resource\PullRequest::class);
+        $reflection = new \ReflectionClass(Resource\PullRequest::class);
 
-        $this->assertTrue($reflectionClass->implementsInterface(Resource\PullRequestInterface::class));
+        $this->assertTrue($reflection->implementsInterface(Resource\PullRequestInterface::class));
     }
 
     /**

--- a/test/Resource/RangeTest.php
+++ b/test/Resource/RangeTest.php
@@ -18,16 +18,16 @@ final class RangeTest extends \PHPUnit_Framework_TestCase
 
     public function testIsFinal()
     {
-        $reflectionClass = new \ReflectionClass(Resource\Range::class);
+        $reflection = new \ReflectionClass(Resource\Range::class);
 
-        $this->assertTrue($reflectionClass->isFinal());
+        $this->assertTrue($reflection->isFinal());
     }
 
     public function testImplementsRangeInterface()
     {
-        $reflectionClass = new \ReflectionClass(Resource\Range::class);
+        $reflection = new \ReflectionClass(Resource\Range::class);
 
-        $this->assertTrue($reflectionClass->implementsInterface(Resource\RangeInterface::class));
+        $this->assertTrue($reflection->implementsInterface(Resource\RangeInterface::class));
     }
 
     public function testDefaults()


### PR DESCRIPTION
This PR

* [x] uses a shorter variable name in tests
