### PR TITLE
Fix: Use newly provided assertions

### DIFF
--- a/test/Resource/AuthorTest.php
+++ b/test/Resource/AuthorTest.php
@@ -18,16 +18,12 @@ final class AuthorTest extends \PHPUnit_Framework_TestCase
 
     public function testIsFinal()
     {
-        $reflection = new \ReflectionClass(Resource\Author::class);
-
-        $this->assertTrue($reflection->isFinal());
+        $this->assertFinal(Resource\Author::class);
     }
 
     public function testImplementsAuthorInterface()
     {
-        $reflection = new \ReflectionClass(Resource\Author::class);
-
-        $this->assertTrue($reflection->implementsInterface(Resource\AuthorInterface::class));
+        $this->assertImplements(Resource\AuthorInterface::class, Resource\Author::class);
     }
 
     /**

--- a/test/Resource/CommitTest.php
+++ b/test/Resource/CommitTest.php
@@ -19,16 +19,12 @@ final class CommitTest extends \PHPUnit_Framework_TestCase
 
     public function testIsFinal()
     {
-        $reflection = new \ReflectionClass(Resource\Commit::class);
-
-        $this->assertTrue($reflection->isFinal());
+        $this->assertFinal(Resource\Commit::class);
     }
 
-    public function testImplementsCommitInterface()
+    public function testImplementsAuthorInterface()
     {
-        $reflection = new \ReflectionClass(Resource\Commit::class);
-
-        $this->assertTrue($reflection->implementsInterface(Resource\CommitInterface::class));
+        $this->assertImplements(Resource\CommitInterface::class, Resource\Commit::class);
     }
 
     /**

--- a/test/Resource/PullRequestTest.php
+++ b/test/Resource/PullRequestTest.php
@@ -19,16 +19,12 @@ final class PullRequestTest extends \PHPUnit_Framework_TestCase
 
     public function testIsFinal()
     {
-        $reflection = new \ReflectionClass(Resource\PullRequest::class);
-
-        $this->assertTrue($reflection->isFinal());
+        $this->assertFinal(Resource\PullRequest::class);
     }
 
     public function testImplementsPullRequestInterface()
     {
-        $reflection = new \ReflectionClass(Resource\PullRequest::class);
-
-        $this->assertTrue($reflection->implementsInterface(Resource\PullRequestInterface::class));
+        $this->assertImplements(Resource\PullRequestInterface::class, Resource\PullRequest::class);
     }
 
     /**

--- a/test/Resource/RangeTest.php
+++ b/test/Resource/RangeTest.php
@@ -18,16 +18,12 @@ final class RangeTest extends \PHPUnit_Framework_TestCase
 
     public function testIsFinal()
     {
-        $reflection = new \ReflectionClass(Resource\Range::class);
-
-        $this->assertTrue($reflection->isFinal());
+        $this->assertFinal(Resource\Range::class);
     }
 
     public function testImplementsRangeInterface()
     {
-        $reflection = new \ReflectionClass(Resource\Range::class);
-
-        $this->assertTrue($reflection->implementsInterface(Resource\RangeInterface::class));
+        $this->assertImplements(Resource\RangeInterface::class, Resource\Range::class);
     }
 
     public function testDefaults()


### PR DESCRIPTION
This PR

* [x] makes use of the newly provided assertions
