### PR TITLE
Fix: Identifier should be greater than 0

### DIFF
--- a/test/Console/GenerateCommandTest.php
+++ b/test/Console/GenerateCommandTest.php
@@ -470,7 +470,7 @@ final class GenerateCommandTest extends \PHPUnit_Framework_TestCase
     {
         $faker = $this->getFaker();
 
-        $id = $faker->unique()->randomNumber();
+        $id = $faker->unique()->numberBetween(1);
         $title = $faker->unique()->sentence();
 
         return new Resource\PullRequest(


### PR DESCRIPTION
This PR

* [x] fixes a test which fails because an identifier is randomly set to `0`

Blocks #138.
