### PR TITLE
Fix: Drop HHVM from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ matrix:
     - php: 7.0
       env: WITH_COVERAGE=true
     - php: 7.1
-    - php: hhvm
-      sudo: required
-      dist: trusty
-      group: edge
 
 cache:
   directories:


### PR DESCRIPTION
This PR

* [x] drops HHVM from the Travis CI build matrix