### PR TITLE
Fix: Collect coverage on PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ matrix:
     - php: 5.6
       env: WITH_CS=true
     - php: 7.0
-      env: WITH_COVERAGE=true
     - php: 7.1
+      env: WITH_COVERAGE=true
 
 cache:
   directories:


### PR DESCRIPTION
This PR

* [x] collects coverage on PHP 7.1 (instead of on PHP 7.0)