### PR TITLE
Fix: Configure preferred installation method in composer.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
   - composer config github-oauth.github.com $GITHUB_TOKEN
 
 install:
-  - composer install --prefer-dist
+  - composer install
 
 before_script:
   - mkdir -p "$HOME/.php-cs-fixer"

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     ],
     "license": "MIT",
     "config": {
+        "preferred-install": "dist",
         "sort-packages": true
     },
     "require": {


### PR DESCRIPTION
This PR

* [x] configures the preferred installation method in `composer.json`

💁‍♂️ For reference, see https://getcomposer.org/doc/06-config.md#preferred-install.