### PR TITLE
Fix: Remove --sort-packages flag from installation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Enjoy the changelog:
 Install locally:
 
 ```bash
-$ composer require --dev --sort-packages localheinz/github-changelog
+$ composer require --dev localheinz/github-changelog
 ```
 
 Create your changelog from within in your project:
@@ -100,7 +100,7 @@ Enjoy the changelog:
 Install locally:
 
 ```bash
-$ composer require --sort-packages localheinz/github-changelog
+$ composer require localheinz/github-changelog
 ```
 
 Retrieve pull requests between references in your application:


### PR DESCRIPTION
This PR

* [x] removes the `--sort-packages` flag from the installation example