### PR TITLE
Fix: Rename methods creating mocks

### DIFF
--- a/test/Unit/Console/GenerateCommandTest.php
+++ b/test/Unit/Console/GenerateCommandTest.php
@@ -29,8 +29,8 @@ final class GenerateCommandTest extends Framework\TestCase
     public function testHasName()
     {
         $command = new Console\GenerateCommand(
-            $this->getClientMock(),
-            $this->getPullRequestRepositoryMock()
+            $this->createClientMock(),
+            $this->createPullRequestRepositoryMock()
         );
 
         $this->assertSame('generate', $command->getName());
@@ -39,8 +39,8 @@ final class GenerateCommandTest extends Framework\TestCase
     public function testHasDescription()
     {
         $command = new Console\GenerateCommand(
-            $this->getClientMock(),
-            $this->getPullRequestRepositoryMock()
+            $this->createClientMock(),
+            $this->createPullRequestRepositoryMock()
         );
 
         $this->assertSame('Generates a changelog from information found between commit references', $command->getDescription());
@@ -56,8 +56,8 @@ final class GenerateCommandTest extends Framework\TestCase
     public function testArgument($name, $required, $description)
     {
         $command = new Console\GenerateCommand(
-            $this->getClientMock(),
-            $this->getPullRequestRepositoryMock()
+            $this->createClientMock(),
+            $this->createPullRequestRepositoryMock()
         );
 
         $this->assertTrue($command->getDefinition()->hasArgument($name));
@@ -111,8 +111,8 @@ final class GenerateCommandTest extends Framework\TestCase
     public function testOption($name, $shortcut, $required, $description, $default)
     {
         $command = new Console\GenerateCommand(
-            $this->getClientMock(),
-            $this->getPullRequestRepositoryMock()
+            $this->createClientMock(),
+            $this->createPullRequestRepositoryMock()
         );
 
         $this->assertTrue($command->getDefinition()->hasOption($name));
@@ -154,7 +154,7 @@ final class GenerateCommandTest extends Framework\TestCase
     {
         $authToken = $this->getFaker()->password();
 
-        $client = $this->getClientMock();
+        $client = $this->createClientMock();
 
         $client
             ->expects($this->once())
@@ -164,12 +164,12 @@ final class GenerateCommandTest extends Framework\TestCase
                 $this->equalTo(Client::AUTH_HTTP_TOKEN)
             );
 
-        $pullRequestRepository = $this->getPullRequestRepositoryMock();
+        $pullRequestRepository = $this->createPullRequestRepositoryMock();
 
         $pullRequestRepository
             ->expects($this->any())
             ->method('items')
-            ->willReturn($this->getRangeMock());
+            ->willReturn($this->createRangeMock());
 
         $command = new Console\GenerateCommand(
             $client,
@@ -195,7 +195,7 @@ final class GenerateCommandTest extends Framework\TestCase
         $startReference = $faker->unique()->sha1;
         $endReference = $faker->unique()->sha1;
 
-        $pullRequestRepository = $this->getPullRequestRepositoryMock();
+        $pullRequestRepository = $this->createPullRequestRepositoryMock();
 
         $pullRequestRepository
             ->expects($this->once())
@@ -206,10 +206,10 @@ final class GenerateCommandTest extends Framework\TestCase
                 $this->equalTo($startReference),
                 $this->equalTo($endReference)
             )
-            ->willReturn($this->getRangeMock([]));
+            ->willReturn($this->createRangeMock([]));
 
         $command = new Console\GenerateCommand(
-            $this->getClientMock(),
+            $this->createClientMock(),
             $pullRequestRepository
         );
 
@@ -234,15 +234,15 @@ final class GenerateCommandTest extends Framework\TestCase
 
         $expectedMessage = 'Could not find any pull requests';
 
-        $pullRequestRepository = $this->getPullRequestRepositoryMock();
+        $pullRequestRepository = $this->createPullRequestRepositoryMock();
 
         $pullRequestRepository
             ->expects($this->any())
             ->method('items')
-            ->willReturn($this->getRangeMock());
+            ->willReturn($this->createRangeMock());
 
         $command = new Console\GenerateCommand(
-            $this->getClientMock(),
+            $this->createClientMock(),
             $pullRequestRepository
         );
 
@@ -269,15 +269,15 @@ final class GenerateCommandTest extends Framework\TestCase
 
         $expectedMessage = 'Could not find any pull requests';
 
-        $pullRequestRepository = $this->getPullRequestRepositoryMock();
+        $pullRequestRepository = $this->createPullRequestRepositoryMock();
 
         $pullRequestRepository
             ->expects($this->any())
             ->method('items')
-            ->willReturn($this->getRangeMock());
+            ->willReturn($this->createRangeMock());
 
         $command = new Console\GenerateCommand(
-            $this->getClientMock(),
+            $this->createClientMock(),
             $pullRequestRepository
         );
 
@@ -329,15 +329,15 @@ final class GenerateCommandTest extends Framework\TestCase
             );
         });
 
-        $pullRequestRepository = $this->getPullRequestRepositoryMock();
+        $pullRequestRepository = $this->createPullRequestRepositoryMock();
 
         $pullRequestRepository
             ->expects($this->any())
             ->method('items')
-            ->willReturn($this->getRangeMock($pullRequests));
+            ->willReturn($this->createRangeMock($pullRequests));
 
         $command = new Console\GenerateCommand(
-            $this->getClientMock(),
+            $this->createClientMock(),
             $pullRequestRepository
         );
 
@@ -374,15 +374,15 @@ final class GenerateCommandTest extends Framework\TestCase
             \count($pullRequests)
         );
 
-        $pullRequestRepository = $this->getPullRequestRepositoryMock();
+        $pullRequestRepository = $this->createPullRequestRepositoryMock();
 
         $pullRequestRepository
             ->expects($this->any())
             ->method('items')
-            ->willReturn($this->getRangeMock($pullRequests));
+            ->willReturn($this->createRangeMock($pullRequests));
 
         $command = new Console\GenerateCommand(
-            $this->getClientMock(),
+            $this->createClientMock(),
             $pullRequestRepository
         );
 
@@ -405,7 +405,7 @@ final class GenerateCommandTest extends Framework\TestCase
 
         $exception = new \Exception('Wait, this should not happen!');
 
-        $pullRequestRepository = $this->getPullRequestRepositoryMock();
+        $pullRequestRepository = $this->createPullRequestRepositoryMock();
 
         $pullRequestRepository
             ->expects($this->any())
@@ -418,7 +418,7 @@ final class GenerateCommandTest extends Framework\TestCase
         );
 
         $command = new Console\GenerateCommand(
-            $this->getClientMock(),
+            $this->createClientMock(),
             $pullRequestRepository
         );
 
@@ -438,7 +438,7 @@ final class GenerateCommandTest extends Framework\TestCase
     /**
      * @return Client|\PHPUnit_Framework_MockObject_MockObject
      */
-    private function getClientMock()
+    private function createClientMock()
     {
         return $this->createMock(Client::class);
     }
@@ -446,7 +446,7 @@ final class GenerateCommandTest extends Framework\TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|Repository\PullRequestRepository
      */
-    private function getPullRequestRepositoryMock()
+    private function createPullRequestRepositoryMock()
     {
         return $this->createMock(Repository\PullRequestRepository::class);
     }
@@ -456,7 +456,7 @@ final class GenerateCommandTest extends Framework\TestCase
      *
      * @return \PHPUnit_Framework_MockObject_MockObject|Resource\RangeInterface
      */
-    private function getRangeMock(array $pullRequests = [])
+    private function createRangeMock(array $pullRequests = [])
     {
         $range = $this->createMock(Resource\RangeInterface::class);
 

--- a/test/Unit/Repository/CommitRepositoryTest.php
+++ b/test/Unit/Repository/CommitRepositoryTest.php
@@ -31,7 +31,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $repository = $faker->slug();
         $sha = $faker->sha1;
 
-        $commitApi = $this->getCommitApiMock();
+        $commitApi = $this->createCommitApiMock();
 
         $expectedItem = $this->commitItem();
 
@@ -67,7 +67,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $repository = $faker->slug();
         $sha = $faker->sha1;
 
-        $api = $this->getCommitApiMock();
+        $api = $this->createCommitApiMock();
 
         $api
             ->expects($this->once())
@@ -98,7 +98,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $repository = $faker->slug();
         $sha = $faker->sha1;
 
-        $commitApi = $this->getCommitApiMock();
+        $commitApi = $this->createCommitApiMock();
 
         $commitApi
             ->expects($this->once())
@@ -132,7 +132,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $repository = $faker->slug();
         $sha = $faker->sha1;
 
-        $commitApi = $this->getCommitApiMock();
+        $commitApi = $this->createCommitApiMock();
 
         $expectedItems = $this->commitItems(15);
 
@@ -166,7 +166,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $sha = $faker->sha1;
         $perPage = $faker->randomNumber();
 
-        $commitApi = $this->getCommitApiMock();
+        $commitApi = $this->createCommitApiMock();
 
         $expectedItems = $this->commitItems(15);
 
@@ -200,7 +200,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $repository = $faker->slug();
         $sha = $faker->sha1;
 
-        $commitApi = $this->getCommitApiMock();
+        $commitApi = $this->createCommitApiMock();
 
         $expectedItems = $this->commitItems(15);
 
@@ -247,7 +247,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $endReference = $startReference;
 
-        $commitApi = $this->getCommitApiMock();
+        $commitApi = $this->createCommitApiMock();
 
         $commitApi
             ->expects($this->never())
@@ -274,7 +274,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitApi = $this->getCommitApiMock();
+        $commitApi = $this->createCommitApiMock();
 
         $commitApi
             ->expects($this->at(0))
@@ -311,7 +311,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitApi = $this->getCommitApiMock();
+        $commitApi = $this->createCommitApiMock();
 
         $commitApi
             ->expects($this->at(0))
@@ -358,7 +358,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitApi = $this->getCommitApiMock();
+        $commitApi = $this->createCommitApiMock();
 
         $startCommit = $this->commitItem();
 
@@ -411,7 +411,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $repository = $faker->slug();
         $startReference = $faker->sha1;
 
-        $commitApi = $this->getCommitApiMock();
+        $commitApi = $this->createCommitApiMock();
 
         $startCommit = $this->commitItem();
 
@@ -452,7 +452,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitApi = $this->getCommitApiMock();
+        $commitApi = $this->createCommitApiMock();
 
         $startCommit = $this->commitItem();
         $startCommit->sha = $faker->sha1;
@@ -548,7 +548,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitApi = $this->getCommitApiMock();
+        $commitApi = $this->createCommitApiMock();
 
         $startCommit = $this->commitItem();
         $startCommit->sha = $faker->sha1;
@@ -662,7 +662,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     /**
      * @return Api\Repository\Commits|\PHPUnit_Framework_MockObject_MockObject
      */
-    private function getCommitApiMock()
+    private function createCommitApiMock()
     {
         return $this->createMock(Api\Repository\Commits::class);
     }

--- a/test/Unit/Repository/PullRequestRepositoryTest.php
+++ b/test/Unit/Repository/PullRequestRepositoryTest.php
@@ -30,7 +30,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         $vendor = $faker->userName;
         $package = $faker->slug();
 
-        $api = $this->getPullRequestApiMock();
+        $api = $this->createPullRequestApiMock();
 
         $expectedItem = $this->pullRequestItem();
 
@@ -46,7 +46,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
 
         $pullRequestRepository = new Repository\PullRequestRepository(
             $api,
-            $this->getCommitRepositoryMock()
+            $this->createCommitRepositoryMock()
         );
 
         $pullRequest = $pullRequestRepository->show(
@@ -69,7 +69,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         $package = $faker->slug();
         $id = $faker->randomNumber();
 
-        $api = $this->getPullRequestApiMock();
+        $api = $this->createPullRequestApiMock();
 
         $api
             ->expects($this->once())
@@ -83,7 +83,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
 
         $pullRequestRepository = new Repository\PullRequestRepository(
             $api,
-            $this->getCommitRepositoryMock()
+            $this->createCommitRepositoryMock()
         );
 
         $pullRequest = $pullRequestRepository->show(
@@ -103,9 +103,9 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         $package = $faker->slug();
         $startReference = $faker->sha1;
 
-        $commitRepository = $this->getCommitRepositoryMock();
+        $commitRepository = $this->createCommitRepositoryMock();
 
-        $range = $this->getRangeMock();
+        $range = $this->createRangeMock();
 
         $range
             ->expects($this->any())
@@ -124,7 +124,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->willReturn($range);
 
         $repository = new Repository\PullRequestRepository(
-            $this->getPullRequestApiMock(),
+            $this->createPullRequestApiMock(),
             $commitRepository
         );
 
@@ -144,7 +144,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $range = $this->getRangeMock();
+        $range = $this->createRangeMock();
 
         $range
             ->expects($this->any())
@@ -155,7 +155,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->never())
             ->method('withPullRequest');
 
-        $commitRepository = $this->getCommitRepositoryMock();
+        $commitRepository = $this->createCommitRepositoryMock();
 
         $commitRepository
             ->expects($this->once())
@@ -169,7 +169,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->willReturn($range);
 
         $repository = new Repository\PullRequestRepository(
-            $this->getPullRequestApiMock(),
+            $this->createPullRequestApiMock(),
             $commitRepository
         );
 
@@ -190,14 +190,14 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitRepository = $this->getCommitRepositoryMock();
+        $commitRepository = $this->createCommitRepositoryMock();
 
         $commit = new Resource\Commit(
             $faker->sha1,
             'I am not a merge commit'
         );
 
-        $range = $this->getRangeMock();
+        $range = $this->createRangeMock();
 
         $range
             ->expects($this->any())
@@ -222,7 +222,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->willReturn($range);
 
         $repository = new Repository\PullRequestRepository(
-            $this->getPullRequestApiMock(),
+            $this->createPullRequestApiMock(),
             $commitRepository
         );
 
@@ -243,7 +243,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitRepository = $this->getCommitRepositoryMock();
+        $commitRepository = $this->createCommitRepositoryMock();
 
         $expectedItem = $this->pullRequestItem();
 
@@ -255,9 +255,9 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             )
         );
 
-        $mutatedRange = $this->getRangeMock();
+        $mutatedRange = $this->createRangeMock();
 
-        $range = $this->getRangeMock();
+        $range = $this->createRangeMock();
 
         $range
             ->expects($this->any())
@@ -283,7 +283,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             )
             ->willReturn($range);
 
-        $api = $this->getPullRequestApiMock();
+        $api = $this->createPullRequestApiMock();
 
         $api
             ->expects($this->once())
@@ -319,7 +319,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitRepository = $this->getCommitRepositoryMock();
+        $commitRepository = $this->createCommitRepositoryMock();
 
         $id = 9000;
 
@@ -331,7 +331,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             )
         );
 
-        $range = $this->getRangeMock();
+        $range = $this->createRangeMock();
 
         $range
             ->expects($this->any())
@@ -355,7 +355,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             )
             ->willReturn($range);
 
-        $pullRequestApi = $this->getPullRequestApiMock();
+        $pullRequestApi = $this->createPullRequestApiMock();
 
         $pullRequestApi
             ->expects($this->once())
@@ -383,7 +383,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     /**
      * @return Api\PullRequest|\PHPUnit_Framework_MockObject_MockObject
      */
-    private function getPullRequestApiMock()
+    private function createPullRequestApiMock()
     {
         return $this->createMock(Api\PullRequest::class);
     }
@@ -391,7 +391,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|Repository\CommitRepository
      */
-    private function getCommitRepositoryMock()
+    private function createCommitRepositoryMock()
     {
         return $this->createMock(Repository\CommitRepository::class);
     }
@@ -399,7 +399,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|Resource\RangeInterface
      */
-    private function getRangeMock()
+    private function createRangeMock()
     {
         return $this->createMock(Resource\RangeInterface::class);
     }

--- a/test/Unit/Resource/RangeTest.php
+++ b/test/Unit/Resource/RangeTest.php
@@ -41,7 +41,7 @@ final class RangeTest extends Framework\TestCase
 
     public function testWithCommitClonesRangeAndAddsCommit()
     {
-        $commit = $this->getCommitMock();
+        $commit = $this->createCommitMock();
 
         $range = new Resource\Range();
 
@@ -56,7 +56,7 @@ final class RangeTest extends Framework\TestCase
 
     public function testWithPullRequestClonesRangeAndAddsPullRequest()
     {
-        $pullRequest = $this->getPullRequestMock();
+        $pullRequest = $this->createPullRequestMock();
 
         $range = new Resource\Range();
 
@@ -72,7 +72,7 @@ final class RangeTest extends Framework\TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|Resource\CommitInterface
      */
-    private function getCommitMock()
+    private function createCommitMock()
     {
         return $this->createMock(Resource\CommitInterface::class);
     }
@@ -80,7 +80,7 @@ final class RangeTest extends Framework\TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject|Resource\PullRequestInterface
      */
-    private function getPullRequestMock()
+    private function createPullRequestMock()
     {
         return $this->createMock(Resource\PullRequestInterface::class);
     }


### PR DESCRIPTION
This PR

* [x] renames methods which create mocks