### PR TITLE
Fix: Add missing throws annotations

### DIFF
--- a/src/Resource/Author.php
+++ b/src/Resource/Author.php
@@ -30,6 +30,8 @@ final class Author implements AuthorInterface
     /**
      * @param string $login
      * @param string $htmlUrl
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct($login, $htmlUrl)
     {

--- a/src/Resource/Commit.php
+++ b/src/Resource/Commit.php
@@ -30,6 +30,8 @@ final class Commit implements CommitInterface
     /**
      * @param string $sha
      * @param string $message
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct($sha, $message)
     {

--- a/src/Resource/PullRequest.php
+++ b/src/Resource/PullRequest.php
@@ -30,6 +30,8 @@ final class PullRequest implements PullRequestInterface
     /**
      * @param string $id
      * @param string $title
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct($id, $title)
     {


### PR DESCRIPTION
This PR

* [x] adds missing `@throws` annotations to docblocks