### PR TITLE
Fix: Remove extra parameter passed in into sprintf()

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -173,8 +173,7 @@ class GenerateCommand extends Command
             $io->success(\sprintf(
                 'Found %s pull request%s.',
                 \count($pullRequests),
-                1 === \count($pullRequests) ? '' : 's',
-                $range
+                1 === \count($pullRequests) ? '' : 's'
             ));
         }
 


### PR DESCRIPTION
This PR

* [x] removes an extra parameter passed in into `sprintf()`