### PR TITLE
Fix: Id should be number

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ array_walk($pullRequests, function (Resource\PullRequestInterface $pullRequest) 
     echo sprintf(
         '- %s (#%s)' . PHP_EOL,
         $pullRequest->title(),
-        $pullRequest->id()
+        $pullRequest->number()
     );
 });
 

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -160,7 +160,7 @@ class GenerateCommand extends Command
                     ],
                     [
                         $pullRequest->title(),
-                        $pullRequest->id(),
+                        $pullRequest->number(),
                     ],
                     $template
                 );

--- a/src/Resource/PullRequest.php
+++ b/src/Resource/PullRequest.php
@@ -20,7 +20,7 @@ final class PullRequest implements PullRequestInterface
     /**
      * @var string
      */
-    private $id;
+    private $number;
 
     /**
      * @var string
@@ -28,23 +28,23 @@ final class PullRequest implements PullRequestInterface
     private $title;
 
     /**
-     * @param string $id
+     * @param string $number
      * @param string $title
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct($id, $title)
+    public function __construct($number, $title)
     {
-        Assert\that($id)->integerish()->greaterThan(0);
+        Assert\that($number)->integerish()->greaterThan(0);
         Assert\that($title)->string();
 
-        $this->id = $id;
+        $this->number = $number;
         $this->title = $title;
     }
 
-    public function id()
+    public function number()
     {
-        return $this->id;
+        return $this->number;
     }
 
     public function title()

--- a/src/Resource/PullRequestInterface.php
+++ b/src/Resource/PullRequestInterface.php
@@ -18,7 +18,7 @@ interface PullRequestInterface
     /**
      * @return string
      */
-    public function id();
+    public function number();
 
     /**
      * @return string

--- a/test/Unit/Console/GenerateCommandTest.php
+++ b/test/Unit/Console/GenerateCommandTest.php
@@ -329,7 +329,7 @@ final class GenerateCommandTest extends Framework\TestCase
                 ],
                 [
                     $pullRequest->title(),
-                    $pullRequest->id(),
+                    $pullRequest->number(),
                 ],
                 $template
             );

--- a/test/Unit/Repository/PullRequestRepositoryTest.php
+++ b/test/Unit/Repository/PullRequestRepositoryTest.php
@@ -40,7 +40,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->with(
                 $this->equalTo($vendor),
                 $this->equalTo($package),
-                $this->equalTo($expectedItem->id)
+                $this->equalTo($expectedItem->number)
             )
             ->willReturn($this->response($expectedItem));
 
@@ -52,12 +52,12 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         $pullRequest = $pullRequestRepository->show(
             $vendor,
             $package,
-            $expectedItem->id
+            $expectedItem->number
         );
 
         $this->assertInstanceOf(Resource\PullRequestInterface::class, $pullRequest);
 
-        $this->assertSame($expectedItem->id, $pullRequest->id());
+        $this->assertSame($expectedItem->number, $pullRequest->number());
         $this->assertSame($expectedItem->title, $pullRequest->title());
     }
 
@@ -251,7 +251,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             $faker->unique()->sha1,
             \sprintf(
                 'Merge pull request #%s from localheinz/fix/directory',
-                $expectedItem->id
+                $expectedItem->number
             )
         );
 
@@ -291,7 +291,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->with(
                 $this->equalTo($vendor),
                 $this->equalTo($package),
-                $this->equalTo($expectedItem->id)
+                $this->equalTo($expectedItem->number)
             )
             ->willReturn($this->response($expectedItem));
 
@@ -413,7 +413,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
 
         $item = new \stdClass();
 
-        $item->id = $faker->unique()->randomNumber();
+        $item->number = $faker->unique()->randomNumber();
         $item->title = $faker->unique()->sentence();
 
         return $item;
@@ -434,7 +434,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
                 '%title%',
             ],
             [
-                $item->id,
+                $item->number,
                 $item->title,
             ],
             $template

--- a/test/Unit/Resource/PullRequestTest.php
+++ b/test/Unit/Resource/PullRequestTest.php
@@ -89,7 +89,7 @@ final class PullRequestTest extends Framework\TestCase
             $title
         );
 
-        $this->assertSame($id, $pullRequest->id());
+        $this->assertSame($id, $pullRequest->number());
         $this->assertSame($title, $pullRequest->title());
     }
 }


### PR DESCRIPTION
This PR

* [x] renames `id()` to `number()`

💁‍♂️ For reference, see https://developer.github.com/v3/pulls/#get-a-single-pull-request.