### PR TITLE
Fix: Consistently return Resource\Range

### DIFF
--- a/src/Repository/CommitRepository.php
+++ b/src/Repository/CommitRepository.php
@@ -39,7 +39,7 @@ class CommitRepository
     public function items($owner, $repository, $startReference, $endReference = null)
     {
         if ($startReference === $endReference) {
-            return [];
+            return new Resource\Range();
         }
 
         $start = $this->show(
@@ -49,7 +49,7 @@ class CommitRepository
         );
 
         if (null === $start) {
-            return [];
+            return new Resource\Range();
         }
 
         $params = [];
@@ -62,7 +62,7 @@ class CommitRepository
             );
 
             if (null === $end) {
-                return [];
+                return new Resource\Range();
             }
 
             $params = [

--- a/test/Unit/Repository/CommitRepositoryTest.php
+++ b/test/Unit/Repository/CommitRepositoryTest.php
@@ -255,14 +255,16 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $commitRepository = new Repository\CommitRepository($commitApi);
 
-        $commits = $commitRepository->items(
+        $range = $commitRepository->items(
             $owner,
             $repository,
             $startReference,
             $endReference
         );
 
-        $this->assertSame([], $commits);
+        $this->assertInstanceOf(Resource\RangeInterface::class, $range);
+        $this->assertEmpty($range->commits());
+        $this->assertEmpty($range->pullRequests());
     }
 
     public function testItemsDoesNotFetchCommitsIfStartCommitCouldNotBeFound()
@@ -292,14 +294,16 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $commitRepository = new Repository\CommitRepository($commitApi);
 
-        $commits = $commitRepository->items(
+        $range = $commitRepository->items(
             $owner,
             $repository,
             $startReference,
             $endReference
         );
 
-        $this->assertSame([], $commits);
+        $this->assertInstanceOf(Resource\RangeInterface::class, $range);
+        $this->assertEmpty($range->commits());
+        $this->assertEmpty($range->pullRequests());
     }
 
     public function testItemsDoesNotFetchCommitsIfEndCommitCouldNotBeFound()
@@ -339,14 +343,16 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $commitRepository = new Repository\CommitRepository($commitApi);
 
-        $commits = $commitRepository->items(
+        $range = $commitRepository->items(
             $owner,
             $repository,
             $startReference,
             $endReference
         );
 
-        $this->assertSame([], $commits);
+        $this->assertInstanceOf(Resource\RangeInterface::class, $range);
+        $this->assertEmpty($range->commits());
+        $this->assertEmpty($range->pullRequests());
     }
 
     public function testItemsFetchesCommitsUsingShaFromEndCommit()


### PR DESCRIPTION
This PR

* [x] consistently returns an instance of `Resource\Range`

Spotted in #177.