### PR TITLE
Enhancement: Throw CommitNotFound exception if commit was not found

### DIFF
--- a/src/Exception/CommitNotFound.php
+++ b/src/Exception/CommitNotFound.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/github-changelog
+ */
+
+namespace Localheinz\GitHub\ChangeLog\Exception;
+
+final class CommitNotFound extends \RuntimeException implements ExceptionInterface
+{
+    public static function fromOwnerRepositoryAndReference(string $owner, string $repository, string $sha): self
+    {
+        return new self(\sprintf(
+            'Could not find commit "%s" in "%s/%s".',
+            $sha,
+            $owner,
+            $repository
+        ));
+    }
+}

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/github-changelog
+ */
+
+namespace Localheinz\GitHub\ChangeLog\Exception;
+
+interface ExceptionInterface
+{
+}

--- a/test/Unit/Exception/CommitNotFoundTest.php
+++ b/test/Unit/Exception/CommitNotFoundTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/github-changelog
+ */
+
+namespace Localheinz\GitHub\ChangeLog\Test\Unit\Exception;
+
+use Localheinz\GitHub\ChangeLog\Exception\CommitNotFound;
+use Localheinz\GitHub\ChangeLog\Exception\ExceptionInterface;
+use PHPUnit\Framework;
+use Refinery29\Test\Util\TestHelper;
+
+final class CommitNotFoundTest extends Framework\TestCase
+{
+    use TestHelper;
+
+    public function testIsFinal()
+    {
+        $this->assertFinal(CommitNotFound::class);
+    }
+
+    public function testExtendsRuntimeException()
+    {
+        $this->assertExtends(\RuntimeException::class, CommitNotFound::class);
+    }
+
+    public function testImplementsExceptionInterface()
+    {
+        $this->assertImplements(ExceptionInterface::class, CommitNotFound::class);
+    }
+
+    public function testFromOwnerRepositoryAndShaCreatesException()
+    {
+        $faker = $this->getFaker();
+
+        $owner = $faker->userName;
+        $repository = \implode(
+            '-',
+            $faker->words()
+        );
+        $sha = $faker->sha1;
+
+        $exception = CommitNotFound::fromOwnerRepositoryAndReference(
+            $owner,
+            $repository,
+            $sha
+        );
+
+        $this->assertInstanceOf(CommitNotFound::class, $exception);
+
+        $message = \sprintf(
+            'Could not find commit "%s" in "%s/%s".',
+            $sha,
+            $owner,
+            $repository
+        );
+
+        $this->assertSame($message, $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+    }
+}

--- a/test/Unit/Repository/CommitRepositoryTest.php
+++ b/test/Unit/Repository/CommitRepositoryTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Localheinz\GitHub\ChangeLog\Test\Unit\Repository;
 
 use Github\Api;
+use Localheinz\GitHub\ChangeLog\Exception\CommitNotFound;
 use Localheinz\GitHub\ChangeLog\Repository;
 use Localheinz\GitHub\ChangeLog\Resource;
 use PHPUnit\Framework;
@@ -59,7 +60,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $this->assertSame($expectedItem->message, $commit->message());
     }
 
-    public function testShowReturnsNullOnFailure()
+    public function testShowThrowsCommitNotFoundOnFailure()
     {
         $faker = $this->getFaker();
 
@@ -81,13 +82,13 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $commitRepository = new Repository\CommitRepository($api);
 
-        $commit = $commitRepository->show(
+        $this->expectException(CommitNotFound::class);
+
+        $commitRepository->show(
             $owner,
             $repository,
             $sha
         );
-
-        $this->assertNull($commit);
     }
 
     public function testAllReturnsEmptyArrayOnFailure()


### PR DESCRIPTION
This PR

* [x] throws a `CommitNotFound` exception if a commit was not found