### PR TITLE
Fix: Rename CommitNotFound to ReferenceNotFound

### DIFF
--- a/src/Exception/ReferenceNotFound.php
+++ b/src/Exception/ReferenceNotFound.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace Localheinz\GitHub\ChangeLog\Exception;
 
-final class CommitNotFound extends \RuntimeException implements ExceptionInterface
+final class ReferenceNotFound extends \RuntimeException implements ExceptionInterface
 {
-    public static function fromOwnerRepositoryAndReference(string $owner, string $repository, string $sha): self
+    public static function fromOwnerRepositoryAndReference(string $owner, string $repository, string $reference): self
     {
         return new self(\sprintf(
-            'Could not find commit "%s" in "%s/%s".',
-            $sha,
+            'Could not find reference "%s" in "%s/%s".',
+            $reference,
             $owner,
             $repository
         ));

--- a/src/Repository/CommitRepository.php
+++ b/src/Repository/CommitRepository.php
@@ -49,7 +49,7 @@ class CommitRepository
                 $repository,
                 $startReference
             );
-        } catch (Exception\CommitNotFound $exception) {
+        } catch (Exception\ReferenceNotFound $exception) {
             return new Resource\Range();
         }
 
@@ -62,7 +62,7 @@ class CommitRepository
                     $repository,
                     $endReference
                 );
-            } catch (Exception\CommitNotFound $exception) {
+            } catch (Exception\ReferenceNotFound $exception) {
                 return new Resource\Range();
             }
 
@@ -109,7 +109,7 @@ class CommitRepository
      * @param string $repository
      * @param string $sha
      *
-     * @throws Exception\CommitNotFound
+     * @throws Exception\ReferenceNotFound
      *
      * @return Resource\CommitInterface
      */
@@ -122,7 +122,7 @@ class CommitRepository
         );
 
         if (!\is_array($response)) {
-            throw Exception\CommitNotFound::fromOwnerRepositoryAndReference(
+            throw Exception\ReferenceNotFound::fromOwnerRepositoryAndReference(
                 $owner,
                 $repository,
                 $sha

--- a/test/Unit/Exception/ReferenceNotFoundTest.php
+++ b/test/Unit/Exception/ReferenceNotFoundTest.php
@@ -13,31 +13,31 @@ declare(strict_types=1);
 
 namespace Localheinz\GitHub\ChangeLog\Test\Unit\Exception;
 
-use Localheinz\GitHub\ChangeLog\Exception\CommitNotFound;
 use Localheinz\GitHub\ChangeLog\Exception\ExceptionInterface;
+use Localheinz\GitHub\ChangeLog\Exception\ReferenceNotFound;
 use PHPUnit\Framework;
 use Refinery29\Test\Util\TestHelper;
 
-final class CommitNotFoundTest extends Framework\TestCase
+final class ReferenceNotFoundTest extends Framework\TestCase
 {
     use TestHelper;
 
     public function testIsFinal()
     {
-        $this->assertFinal(CommitNotFound::class);
+        $this->assertFinal(ReferenceNotFound::class);
     }
 
     public function testExtendsRuntimeException()
     {
-        $this->assertExtends(\RuntimeException::class, CommitNotFound::class);
+        $this->assertExtends(\RuntimeException::class, ReferenceNotFound::class);
     }
 
     public function testImplementsExceptionInterface()
     {
-        $this->assertImplements(ExceptionInterface::class, CommitNotFound::class);
+        $this->assertImplements(ExceptionInterface::class, ReferenceNotFound::class);
     }
 
-    public function testFromOwnerRepositoryAndShaCreatesException()
+    public function testFromOwnerRepositoryAndReferenceCreatesException()
     {
         $faker = $this->getFaker();
 
@@ -46,19 +46,19 @@ final class CommitNotFoundTest extends Framework\TestCase
             '-',
             $faker->words()
         );
-        $sha = $faker->sha1;
+        $reference = $faker->sha1;
 
-        $exception = CommitNotFound::fromOwnerRepositoryAndReference(
+        $exception = ReferenceNotFound::fromOwnerRepositoryAndReference(
             $owner,
             $repository,
-            $sha
+            $reference
         );
 
-        $this->assertInstanceOf(CommitNotFound::class, $exception);
+        $this->assertInstanceOf(ReferenceNotFound::class, $exception);
 
         $message = \sprintf(
-            'Could not find commit "%s" in "%s/%s".',
-            $sha,
+            'Could not find reference "%s" in "%s/%s".',
+            $reference,
             $owner,
             $repository
         );

--- a/test/Unit/Repository/CommitRepositoryTest.php
+++ b/test/Unit/Repository/CommitRepositoryTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Localheinz\GitHub\ChangeLog\Test\Unit\Repository;
 
 use Github\Api;
-use Localheinz\GitHub\ChangeLog\Exception\CommitNotFound;
+use Localheinz\GitHub\ChangeLog\Exception\ReferenceNotFound;
 use Localheinz\GitHub\ChangeLog\Repository;
 use Localheinz\GitHub\ChangeLog\Resource;
 use PHPUnit\Framework;
@@ -82,7 +82,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $commitRepository = new Repository\CommitRepository($api);
 
-        $this->expectException(CommitNotFound::class);
+        $this->expectException(ReferenceNotFound::class);
 
         $commitRepository->show(
             $owner,


### PR DESCRIPTION
This PR

* [x] renames `CommitNotFound` to `ReferenceNotFound`

Follows #181.
