### PR TITLE
Fix: Consistently name variables, parameters and methods

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -86,7 +86,7 @@ class GenerateCommand extends Command
                 't',
                 Input\InputOption::VALUE_OPTIONAL,
                 'The template to use for rendering a pull request',
-                '- %title% (#%id%)'
+                '- %title% (#%number%)'
             );
     }
 
@@ -111,7 +111,7 @@ class GenerateCommand extends Command
         }
 
         $owner = $input->getArgument('owner');
-        $repository = $input->getArgument('repository');
+        $name = $input->getArgument('repository');
         $startReference = $input->getArgument('start-reference');
         $endReference = $input->getArgument('end-reference');
 
@@ -123,14 +123,14 @@ class GenerateCommand extends Command
         $io->section(\sprintf(
             'Pull Requests for %s/%s %s',
             $owner,
-            $repository,
+            $name,
             $range
         ));
 
         try {
             $range = $this->pullRequestRepository->items(
                 $owner,
-                $repository,
+                $name,
                 $startReference,
                 $endReference
             );
@@ -156,7 +156,7 @@ class GenerateCommand extends Command
                 $message = \str_replace(
                     [
                         '%title%',
-                        '%id%',
+                        '%number%',
                     ],
                     [
                         $pullRequest->title(),

--- a/src/Exception/ReferenceNotFound.php
+++ b/src/Exception/ReferenceNotFound.php
@@ -15,13 +15,13 @@ namespace Localheinz\GitHub\ChangeLog\Exception;
 
 final class ReferenceNotFound extends \RuntimeException implements ExceptionInterface
 {
-    public static function fromOwnerRepositoryAndReference(string $owner, string $repository, string $reference): self
+    public static function fromOwnerNameAndReference(string $owner, string $name, string $reference): self
     {
         return new self(\sprintf(
             'Could not find reference "%s" in "%s/%s".',
             $reference,
             $owner,
-            $repository
+            $name
         ));
     }
 }

--- a/src/Repository/CommitRepository.php
+++ b/src/Repository/CommitRepository.php
@@ -31,13 +31,13 @@ class CommitRepository
 
     /**
      * @param string      $owner
-     * @param string      $repository
+     * @param string      $name
      * @param string      $startReference
      * @param null|string $endReference
      *
      * @return Resource\Range
      */
-    public function items($owner, $repository, $startReference, $endReference = null)
+    public function items($owner, $name, $startReference, $endReference = null)
     {
         if ($startReference === $endReference) {
             return new Resource\Range();
@@ -46,7 +46,7 @@ class CommitRepository
         try {
             $start = $this->show(
                 $owner,
-                $repository,
+                $name,
                 $startReference
             );
         } catch (Exception\ReferenceNotFound $exception) {
@@ -59,7 +59,7 @@ class CommitRepository
             try {
                 $end = $this->show(
                     $owner,
-                    $repository,
+                    $name,
                     $endReference
                 );
             } catch (Exception\ReferenceNotFound $exception) {
@@ -71,7 +71,7 @@ class CommitRepository
             ];
         }
 
-        $commits = $this->all($owner, $repository, $params)->commits();
+        $commits = $this->all($owner, $name, $params)->commits();
 
         $range = new Resource\Range();
 
@@ -97,7 +97,7 @@ class CommitRepository
                     'sha' => $tail->sha(),
                 ];
 
-                $commits = $this->all($owner, $repository, $params)->commits();
+                $commits = $this->all($owner, $name, $params)->commits();
             }
         }
 
@@ -106,25 +106,25 @@ class CommitRepository
 
     /**
      * @param string $owner
-     * @param string $repository
+     * @param string $name
      * @param string $sha
      *
      * @throws Exception\ReferenceNotFound
      *
      * @return Resource\CommitInterface
      */
-    public function show($owner, $repository, $sha)
+    public function show($owner, $name, $sha)
     {
         $response = $this->api->show(
             $owner,
-            $repository,
+            $name,
             $sha
         );
 
         if (!\is_array($response)) {
-            throw Exception\ReferenceNotFound::fromOwnerRepositoryAndReference(
+            throw Exception\ReferenceNotFound::fromOwnerNameAndReference(
                 $owner,
-                $repository,
+                $name,
                 $sha
             );
         }
@@ -137,12 +137,12 @@ class CommitRepository
 
     /**
      * @param string $owner
-     * @param string $repository
+     * @param string $name
      * @param array  $params
      *
      * @return Resource\Range
      */
-    public function all($owner, $repository, array $params = [])
+    public function all($owner, $name, array $params = [])
     {
         $range = new Resource\Range();
 
@@ -152,7 +152,7 @@ class CommitRepository
 
         $response = $this->api->all(
             $owner,
-            $repository,
+            $name,
             $params
         );
 

--- a/src/Repository/PullRequestRepository.php
+++ b/src/Repository/PullRequestRepository.php
@@ -36,17 +36,17 @@ class PullRequestRepository
 
     /**
      * @param string $owner
-     * @param string $repository
-     * @param string $id
+     * @param string $name
+     * @param string $number
      *
      * @return null|Resource\PullRequestInterface
      */
-    public function show($owner, $repository, $id)
+    public function show($owner, $name, $number)
     {
         $response = $this->api->show(
             $owner,
-            $repository,
-            $id
+            $name,
+            $number
         );
 
         if (!\is_array($response)) {
@@ -61,34 +61,34 @@ class PullRequestRepository
 
     /**
      * @param string      $owner
-     * @param string      $repository
+     * @param string      $name
      * @param string      $startReference
      * @param null|string $endReference
      *
      * @return Resource\Range
      */
-    public function items($owner, $repository, $startReference, $endReference = null)
+    public function items($owner, $name, $startReference, $endReference = null)
     {
         $range = $this->commitRepository->items(
             $owner,
-            $repository,
+            $name,
             $startReference,
             $endReference
         );
 
         $commits = $range->commits();
 
-        \array_walk($commits, function (Resource\CommitInterface $commit) use (&$range, $owner, $repository) {
-            if (0 === \preg_match('/^Merge pull request #(?P<id>\d+)/', $commit->message(), $matches)) {
+        \array_walk($commits, function (Resource\CommitInterface $commit) use (&$range, $owner, $name) {
+            if (0 === \preg_match('/^Merge pull request #(?P<number>\d+)/', $commit->message(), $matches)) {
                 return;
             }
 
-            $id = $matches['id'];
+            $number = $matches['number'];
 
             $pullRequest = $this->show(
                 $owner,
-                $repository,
-                $id
+                $name,
+                $number
             );
 
             if (null === $pullRequest) {

--- a/test/Unit/Console/GenerateCommandTest.php
+++ b/test/Unit/Console/GenerateCommandTest.php
@@ -141,7 +141,7 @@ final class GenerateCommandTest extends Framework\TestCase
                 't',
                 false,
                 'The template to use for rendering a pull request',
-                '- %title% (#%id%)',
+                '- %title% (#%number%)',
             ],
         ];
 
@@ -197,7 +197,7 @@ final class GenerateCommandTest extends Framework\TestCase
         $faker = $this->getFaker();
 
         $owner = $faker->unique()->userName;
-        $repository = $faker->unique()->slug();
+        $name = $faker->unique()->slug();
         $startReference = $faker->unique()->sha1;
         $endReference = $faker->unique()->sha1;
 
@@ -208,7 +208,7 @@ final class GenerateCommandTest extends Framework\TestCase
             ->method('items')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->equalTo($startReference),
                 $this->equalTo($endReference)
             )
@@ -223,7 +223,7 @@ final class GenerateCommandTest extends Framework\TestCase
 
         $tester->execute([
             'owner' => $owner,
-            'repository' => $repository,
+            'repository' => $name,
             'start-reference' => $startReference,
             'end-reference' => $endReference,
         ]);
@@ -234,7 +234,7 @@ final class GenerateCommandTest extends Framework\TestCase
         $faker = $this->getFaker();
 
         $owner = $faker->userName;
-        $repository = $faker->slug();
+        $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
@@ -256,7 +256,7 @@ final class GenerateCommandTest extends Framework\TestCase
 
         $exitCode = $tester->execute([
             'owner' => $owner,
-            'repository' => $repository,
+            'repository' => $name,
             'start-reference' => $startReference,
             'end-reference' => $endReference,
         ]);
@@ -270,7 +270,7 @@ final class GenerateCommandTest extends Framework\TestCase
         $faker = $this->getFaker();
 
         $owner = $faker->userName;
-        $repository = $faker->slug();
+        $name = $faker->slug();
         $startReference = $faker->sha1;
 
         $expectedMessage = 'Could not find any pull requests';
@@ -291,7 +291,7 @@ final class GenerateCommandTest extends Framework\TestCase
 
         $exitCode = $tester->execute([
             'owner' => $owner,
-            'repository' => $repository,
+            'repository' => $name,
             'start-reference' => $startReference,
             'end-reference' => null,
         ]);
@@ -305,14 +305,14 @@ final class GenerateCommandTest extends Framework\TestCase
         $faker = $this->getFaker();
 
         $owner = $faker->userName;
-        $repository = $faker->slug();
+        $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
         $count = $faker->numberBetween(1, 5);
 
         $pullRequests = $this->pullRequests($count);
 
-        $template = '- %title% (#%id%)';
+        $template = '- %title% (#%number%)';
 
         $expectedMessages = [
             \sprintf(
@@ -325,7 +325,7 @@ final class GenerateCommandTest extends Framework\TestCase
             $expectedMessages[] = \str_replace(
                 [
                     '%title%',
-                    '%id%',
+                    '%number%',
                 ],
                 [
                     $pullRequest->title(),
@@ -351,7 +351,7 @@ final class GenerateCommandTest extends Framework\TestCase
 
         $exitCode = $tester->execute([
             'owner' => $owner,
-            'repository' => $repository,
+            'repository' => $name,
             'start-reference' => $startReference,
             'end-reference' => $endReference,
             '--template' => $template,
@@ -369,7 +369,7 @@ final class GenerateCommandTest extends Framework\TestCase
         $faker = $this->getFaker();
 
         $owner = $faker->userName;
-        $repository = $faker->slug();
+        $name = $faker->slug();
         $startReference = $faker->sha1;
         $count = $faker->numberBetween(1, 5);
 
@@ -396,7 +396,7 @@ final class GenerateCommandTest extends Framework\TestCase
 
         $exitCode = $tester->execute([
             'owner' => $owner,
-            'repository' => $repository,
+            'repository' => $name,
             'start-reference' => $startReference,
             'end-reference' => null,
         ]);
@@ -481,11 +481,11 @@ final class GenerateCommandTest extends Framework\TestCase
     {
         $faker = $this->getFaker();
 
-        $id = $faker->unique()->numberBetween(1);
+        $number = $faker->unique()->numberBetween(1);
         $title = $faker->unique()->sentence();
 
         return new Resource\PullRequest(
-            $id,
+            $number,
             $title
         );
     }

--- a/test/Unit/Exception/ReferenceNotFoundTest.php
+++ b/test/Unit/Exception/ReferenceNotFoundTest.php
@@ -42,15 +42,12 @@ final class ReferenceNotFoundTest extends Framework\TestCase
         $faker = $this->getFaker();
 
         $owner = $faker->userName;
-        $repository = \implode(
-            '-',
-            $faker->words()
-        );
+        $name = $faker->slug();
         $reference = $faker->sha1;
 
-        $exception = ReferenceNotFound::fromOwnerRepositoryAndReference(
+        $exception = ReferenceNotFound::fromOwnerNameAndReference(
             $owner,
-            $repository,
+            $name,
             $reference
         );
 
@@ -60,7 +57,7 @@ final class ReferenceNotFoundTest extends Framework\TestCase
             'Could not find reference "%s" in "%s/%s".',
             $reference,
             $owner,
-            $repository
+            $name
         );
 
         $this->assertSame($message, $exception->getMessage());

--- a/test/Unit/Repository/CommitRepositoryTest.php
+++ b/test/Unit/Repository/CommitRepositoryTest.php
@@ -29,7 +29,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $faker = $this->getFaker();
 
         $owner = $faker->userName;
-        $repository = $faker->slug();
+        $name = $faker->slug();
         $sha = $faker->sha1;
 
         $commitApi = $this->createCommitApiMock();
@@ -41,7 +41,7 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->method('show')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->equalTo($sha)
             )
             ->willReturn($this->response($expectedItem));
@@ -50,7 +50,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $commit = $commitRepository->show(
             $owner,
-            $repository,
+            $name,
             $sha
         );
 
@@ -65,7 +65,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $faker = $this->getFaker();
 
         $owner = $faker->userName;
-        $repository = $faker->slug();
+        $name = $faker->slug();
         $sha = $faker->sha1;
 
         $api = $this->createCommitApiMock();
@@ -75,7 +75,7 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->method('show')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->equalTo($sha)
             )
             ->willReturn('failure');
@@ -86,7 +86,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $commitRepository->show(
             $owner,
-            $repository,
+            $name,
             $sha
         );
     }
@@ -96,7 +96,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $faker = $this->getFaker();
 
         $owner = $faker->userName;
-        $repository = $faker->slug();
+        $name = $faker->slug();
         $sha = $faker->sha1;
 
         $commitApi = $this->createCommitApiMock();
@@ -106,7 +106,7 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->method('all')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->arrayHasKeyAndValue('sha', $sha)
             )
             ->willReturn('snafu');
@@ -115,7 +115,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $range = $commitRepository->all(
             $owner,
-            $repository,
+            $name,
             [
                 'sha' => $sha,
             ]
@@ -130,7 +130,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $faker = $this->getFaker();
 
         $owner = $faker->userName;
-        $repository = $faker->slug();
+        $name = $faker->slug();
         $sha = $faker->sha1;
 
         $commitApi = $this->createCommitApiMock();
@@ -142,7 +142,7 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->method('all')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->arrayHasKeyAndValue('per_page', 250)
             )
             ->willReturn($this->responseFromItems($expectedItems));
@@ -151,7 +151,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $commitRepository->all(
             $owner,
-            $repository,
+            $name,
             [
                 'sha' => $sha,
             ]
@@ -163,7 +163,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $faker = $this->getFaker();
 
         $owner = $faker->userName;
-        $repository = $faker->slug();
+        $name = $faker->slug();
         $sha = $faker->sha1;
         $perPage = $faker->randomNumber();
 
@@ -176,7 +176,7 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->method('all')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->arrayHasKeyAndValue('per_page', $perPage)
             )
             ->willReturn($this->responseFromItems($expectedItems));
@@ -185,7 +185,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $commitRepository->all(
             $owner,
-            $repository,
+            $name,
             [
                 'sha' => $sha,
                 'per_page' => $perPage,
@@ -198,7 +198,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $faker = $this->getFaker();
 
         $owner = $faker->userName;
-        $repository = $faker->slug();
+        $name = $faker->slug();
         $sha = $faker->sha1;
 
         $commitApi = $this->createCommitApiMock();
@@ -210,14 +210,14 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->method('all')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->arrayHasKeyAndValue('sha', $sha)
             )
             ->willReturn($this->responseFromItems($expectedItems));
 
         $commitRepository = new Repository\CommitRepository($commitApi);
 
-        $range = $commitRepository->all($owner, $repository, [
+        $range = $commitRepository->all($owner, $name, [
             'sha' => $sha,
         ]);
 
@@ -243,7 +243,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $faker = $this->getFaker();
 
         $owner = $faker->userName;
-        $repository = $faker->slug();
+        $name = $faker->slug();
         $startReference = $faker->sha1;
 
         $endReference = $startReference;
@@ -258,7 +258,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $range = $commitRepository->items(
             $owner,
-            $repository,
+            $name,
             $startReference,
             $endReference
         );
@@ -273,7 +273,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $faker = $this->getFaker();
 
         $owner = $faker->userName;
-        $repository = $faker->slug();
+        $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
@@ -284,7 +284,7 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->method('show')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->equalTo($startReference)
             )
             ->willReturn(null);
@@ -297,7 +297,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $range = $commitRepository->items(
             $owner,
-            $repository,
+            $name,
             $startReference,
             $endReference
         );
@@ -312,7 +312,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $faker = $this->getFaker();
 
         $owner = $faker->userName;
-        $repository = $faker->slug();
+        $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
@@ -323,7 +323,7 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->method('show')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->equalTo($startReference)
             )
             ->willReturn($this->response($this->commitItem()));
@@ -333,7 +333,7 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->method('show')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->equalTo($endReference)
             )
             ->willReturn(null);
@@ -346,7 +346,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $range = $commitRepository->items(
             $owner,
-            $repository,
+            $name,
             $startReference,
             $endReference
         );
@@ -361,7 +361,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $faker = $this->getFaker();
 
         $owner = $faker->userName;
-        $repository = $faker->slug();
+        $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
@@ -374,7 +374,7 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->method('show')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->equalTo($startReference)
             )
             ->willReturn($this->response($startCommit));
@@ -386,7 +386,7 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->method('show')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->equalTo($endReference)
             )
             ->willReturn($this->response($endCommit));
@@ -396,7 +396,7 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->method('all')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->arrayHasKeyAndValue('sha', $endCommit->sha)
             );
 
@@ -404,7 +404,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $commitRepository->items(
             $owner,
-            $repository,
+            $name,
             $startReference,
             $endReference
         );
@@ -415,7 +415,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $faker = $this->getFaker();
 
         $owner = $faker->userName;
-        $repository = $faker->slug();
+        $name = $faker->slug();
         $startReference = $faker->sha1;
 
         $commitApi = $this->createCommitApiMock();
@@ -427,7 +427,7 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->method('show')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->equalTo($startReference)
             )
             ->willReturn($this->response($startCommit));
@@ -437,7 +437,7 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->method('all')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->arrayNotHasKey('sha')
             );
 
@@ -445,7 +445,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $commitRepository->items(
             $owner,
-            $repository,
+            $name,
             $startReference
         );
     }
@@ -455,7 +455,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $faker = $this->getFaker();
 
         $owner = $faker->userName;
-        $repository = $faker->slug();
+        $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
@@ -469,7 +469,7 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->method('show')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->equalTo($startReference)
             )
             ->willReturn($this->response($startCommit));
@@ -482,7 +482,7 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->method('show')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->equalTo($endReference)
             )
             ->willReturn($this->response($endCommit));
@@ -512,7 +512,7 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->method('all')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->arrayHasKeyAndValue('sha', $endCommit->sha)
             )
             ->willReturn($this->responseFromItems($segment));
@@ -521,7 +521,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $range = $commitRepository->items(
             $owner,
-            $repository,
+            $name,
             $startReference,
             $endReference
         );
@@ -551,7 +551,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $faker = $this->getFaker();
 
         $owner = $faker->userName;
-        $repository = $faker->slug();
+        $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
@@ -565,7 +565,7 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->method('show')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->equalTo($startReference)
             )
             ->willReturn($this->response($startCommit));
@@ -578,7 +578,7 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->method('show')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->equalTo($endReference)
             )
             ->willReturn($this->response($endCommit));
@@ -622,7 +622,7 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->method('all')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->arrayHasKeyAndValue('sha', $endCommit->sha)
             )
             ->willReturn($this->responseFromItems($firstSegment));
@@ -632,7 +632,7 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->method('all')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->arrayHasKeyAndValue('sha', $firstCommitFromFirstSegment->sha)
             )
             ->willReturn($this->responseFromItems($secondSegment));
@@ -641,7 +641,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $range = $commitRepository->items(
             $owner,
-            $repository,
+            $name,
             $startReference,
             $endReference
         );

--- a/test/Unit/Repository/PullRequestRepositoryTest.php
+++ b/test/Unit/Repository/PullRequestRepositoryTest.php
@@ -27,8 +27,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->getFaker();
 
-        $vendor = $faker->userName;
-        $package = $faker->slug();
+        $owner = $faker->userName;
+        $name = $faker->slug();
 
         $api = $this->createPullRequestApiMock();
 
@@ -38,8 +38,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('show')
             ->with(
-                $this->equalTo($vendor),
-                $this->equalTo($package),
+                $this->equalTo($owner),
+                $this->equalTo($name),
                 $this->equalTo($expectedItem->number)
             )
             ->willReturn($this->response($expectedItem));
@@ -50,8 +50,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         );
 
         $pullRequest = $pullRequestRepository->show(
-            $vendor,
-            $package,
+            $owner,
+            $name,
             $expectedItem->number
         );
 
@@ -65,9 +65,9 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->getFaker();
 
-        $vendor = $faker->userName;
-        $package = $faker->slug();
-        $id = $faker->randomNumber();
+        $owner = $faker->userName;
+        $name = $faker->slug();
+        $number = $faker->randomNumber();
 
         $api = $this->createPullRequestApiMock();
 
@@ -75,9 +75,9 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('show')
             ->with(
-                $this->equalTo($vendor),
-                $this->equalTo($package),
-                $this->equalTo($id)
+                $this->equalTo($owner),
+                $this->equalTo($name),
+                $this->equalTo($number)
             )
             ->willReturn('snafu');
 
@@ -87,9 +87,9 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         );
 
         $pullRequest = $pullRequestRepository->show(
-            $vendor,
-            $package,
-            $id
+            $owner,
+            $name,
+            $number
         );
 
         $this->assertNull($pullRequest);
@@ -99,8 +99,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->getFaker();
 
-        $vendor = $faker->userName;
-        $package = $faker->slug();
+        $owner = $faker->userName;
+        $name = $faker->slug();
         $startReference = $faker->sha1;
 
         $commitRepository = $this->createCommitRepositoryMock();
@@ -116,8 +116,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('items')
             ->with(
-                $this->equalTo($vendor),
-                $this->equalTo($package),
+                $this->equalTo($owner),
+                $this->equalTo($name),
                 $this->equalTo($startReference),
                 $this->equalTo(null)
             )
@@ -129,8 +129,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         );
 
         $repository->items(
-            $vendor,
-            $package,
+            $owner,
+            $name,
             $startReference
         );
     }
@@ -139,8 +139,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->getFaker();
 
-        $vendor = $faker->userName;
-        $package = $faker->slug();
+        $owner = $faker->userName;
+        $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
@@ -161,8 +161,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('items')
             ->with(
-                $this->equalTo($vendor),
-                $this->equalTo($package),
+                $this->equalTo($owner),
+                $this->equalTo($name),
                 $this->equalTo($startReference),
                 $this->equalTo($endReference)
             )
@@ -174,8 +174,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         );
 
         $repository->items(
-            $vendor,
-            $package,
+            $owner,
+            $name,
             $startReference,
             $endReference
         );
@@ -185,8 +185,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->getFaker();
 
-        $vendor = $faker->userName;
-        $package = $faker->slug();
+        $owner = $faker->userName;
+        $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
@@ -214,8 +214,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('items')
             ->with(
-                $this->equalTo($vendor),
-                $this->equalTo($package),
+                $this->equalTo($owner),
+                $this->equalTo($name),
                 $this->equalTo($startReference),
                 $this->equalTo($endReference)
             )
@@ -227,8 +227,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         );
 
         $repository->items(
-            $vendor,
-            $package,
+            $owner,
+            $name,
             $startReference,
             $endReference
         );
@@ -238,8 +238,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->getFaker();
 
-        $vendor = $faker->userName;
-        $package = $faker->slug();
+        $owner = $faker->userName;
+        $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
@@ -276,8 +276,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('items')
             ->with(
-                $this->equalTo($vendor),
-                $this->equalTo($package),
+                $this->equalTo($owner),
+                $this->equalTo($name),
                 $this->equalTo($startReference),
                 $this->equalTo($endReference)
             )
@@ -289,8 +289,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('show')
             ->with(
-                $this->equalTo($vendor),
-                $this->equalTo($package),
+                $this->equalTo($owner),
+                $this->equalTo($name),
                 $this->equalTo($expectedItem->number)
             )
             ->willReturn($this->response($expectedItem));
@@ -301,8 +301,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         );
 
         $actualRange = $repository->items(
-            $vendor,
-            $package,
+            $owner,
+            $name,
             $startReference,
             $endReference
         );
@@ -315,19 +315,19 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         $faker = $this->getFaker();
 
         $owner = $faker->userName;
-        $repository = $faker->slug();
+        $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
         $commitRepository = $this->createCommitRepositoryMock();
 
-        $id = 9000;
+        $number = 9000;
 
         $mergeCommit = new Resource\Commit(
             $faker->sha1,
             \sprintf(
                 'Merge pull request #%s from localheinz/fix/directory',
-                $id
+                $number
             )
         );
 
@@ -349,7 +349,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->method('items')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
+                $this->equalTo($name),
                 $this->equalTo($startReference),
                 $this->equalTo($endReference)
             )
@@ -362,8 +362,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->method('show')
             ->with(
                 $this->equalTo($owner),
-                $this->equalTo($repository),
-                $this->equalTo($id)
+                $this->equalTo($name),
+                $this->equalTo($number)
             )
             ->willReturn(null);
 
@@ -374,7 +374,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
 
         $pullRequestRepository->items(
             $owner,
-            $repository,
+            $name,
             $startReference,
             $endReference
         );
@@ -430,7 +430,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
 
         $body = \str_replace(
             [
-                '%id%',
+                '%number%',
                 '%title%',
             ],
             [

--- a/test/Unit/Repository/_response/pull-request.json
+++ b/test/Unit/Repository/_response/pull-request.json
@@ -10,7 +10,7 @@
     "review_comment_url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments/{number}",
     "comments_url": "https://api.github.com/repos/octocat/Hello-World/issues/1347/comments",
     "statuses_url": "https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e",
-    "number": %id%,
+    "number": %number%,
     "state": "open",
     "title": "%title%",
     "body": "Please pull these awesome changes",

--- a/test/Unit/Resource/PullRequestTest.php
+++ b/test/Unit/Resource/PullRequestTest.php
@@ -33,23 +33,23 @@ final class PullRequestTest extends Framework\TestCase
     }
 
     /**
-     * @dataProvider providerInvalidId
+     * @dataProvider providerInvalidNumber
      *
-     * @param mixed $id
+     * @param mixed $number
      */
-    public function testConstructorRejectsInvalidId($id)
+    public function testConstructorRejectsInvalidNumber($number)
     {
         $this->expectException(\InvalidArgumentException::class);
 
         $title = $this->getFaker()->sentence();
 
         new Resource\PullRequest(
-            $id,
+            $number,
             $title
         );
     }
 
-    public function providerInvalidId(): \Generator
+    public function providerInvalidNumber(): \Generator
     {
         return $this->provideDataFrom(
             new DataProvider\InvalidIntegerish(),
@@ -81,15 +81,15 @@ final class PullRequestTest extends Framework\TestCase
     {
         $faker = $this->getFaker();
 
-        $id = $faker->numberBetween(1);
+        $number = $faker->numberBetween(1);
         $title = $faker->sentence();
 
         $pullRequest = new Resource\PullRequest(
-            $id,
+            $number,
             $title
         );
 
-        $this->assertSame($id, $pullRequest->number());
+        $this->assertSame($number, $pullRequest->number());
         $this->assertSame($title, $pullRequest->title());
     }
 }


### PR DESCRIPTION
This PR

* [x] consistently names variables, parameters, and methods