### PR TITLE
Fix: Do not use array_push() where not necessary

### DIFF
--- a/test/Unit/Console/GenerateCommandTest.php
+++ b/test/Unit/Console/GenerateCommandTest.php
@@ -500,7 +500,7 @@ final class GenerateCommandTest extends Framework\TestCase
         $pullRequests = [];
 
         for ($i = 0; $i < $count; ++$i) {
-            \array_push($pullRequests, $this->pullRequest());
+            $pullRequests[] = $this->pullRequest();
         }
 
         return $pullRequests;

--- a/test/Unit/Repository/CommitRepositoryTest.php
+++ b/test/Unit/Repository/CommitRepositoryTest.php
@@ -702,7 +702,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $items = [];
 
         for ($i = 0; $i < $count; ++$i) {
-            \array_push($items, $this->commitItem());
+            $items[] = $this->commitItem();
         }
 
         return $items;


### PR DESCRIPTION
This PR

* [x] removes usages of `array_push()` where it is not necessary