### PR TITLE
Fix: Extract interfaces

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -32,7 +32,7 @@ class GenerateCommand extends Command
     private $client;
 
     /**
-     * @var Repository\PullRequestRepository
+     * @var Repository\PullRequestRepositoryInterface
      */
     private $pullRequestRepository;
 
@@ -41,7 +41,7 @@ class GenerateCommand extends Command
      */
     private $stopwatch;
 
-    public function __construct(Client $client, Repository\PullRequestRepository $pullRequestRepository)
+    public function __construct(Client $client, Repository\PullRequestRepositoryInterface $pullRequestRepository)
     {
         parent::__construct();
 

--- a/src/Repository/CommitRepository.php
+++ b/src/Repository/CommitRepository.php
@@ -17,7 +17,7 @@ use Github\Api;
 use Localheinz\GitHub\ChangeLog\Exception;
 use Localheinz\GitHub\ChangeLog\Resource;
 
-class CommitRepository
+final class CommitRepository implements CommitRepositoryInterface
 {
     /**
      * @var Api\Repository\Commits
@@ -29,14 +29,6 @@ class CommitRepository
         $this->api = $api;
     }
 
-    /**
-     * @param string      $owner
-     * @param string      $name
-     * @param string      $startReference
-     * @param null|string $endReference
-     *
-     * @return Resource\Range
-     */
     public function items($owner, $name, $startReference, $endReference = null)
     {
         if ($startReference === $endReference) {
@@ -104,15 +96,6 @@ class CommitRepository
         return $range;
     }
 
-    /**
-     * @param string $owner
-     * @param string $name
-     * @param string $sha
-     *
-     * @throws Exception\ReferenceNotFound
-     *
-     * @return Resource\CommitInterface
-     */
     public function show($owner, $name, $sha)
     {
         $response = $this->api->show(
@@ -135,13 +118,6 @@ class CommitRepository
         );
     }
 
-    /**
-     * @param string $owner
-     * @param string $name
-     * @param array  $params
-     *
-     * @return Resource\Range
-     */
     public function all($owner, $name, array $params = [])
     {
         $range = new Resource\Range();

--- a/src/Repository/CommitRepositoryInterface.php
+++ b/src/Repository/CommitRepositoryInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/github-changelog
+ */
+
+namespace Localheinz\GitHub\ChangeLog\Repository;
+
+use Localheinz\GitHub\ChangeLog\Exception;
+use Localheinz\GitHub\ChangeLog\Resource;
+
+interface CommitRepositoryInterface
+{
+    /**
+     * @param string      $owner
+     * @param string      $name
+     * @param string      $startReference
+     * @param null|string $endReference
+     *
+     * @return Resource\Range
+     */
+    public function items($owner, $name, $startReference, $endReference = null);
+
+    /**
+     * @param string $owner
+     * @param string $name
+     * @param string $sha
+     *
+     * @throws Exception\ReferenceNotFound
+     *
+     * @return Resource\CommitInterface
+     */
+    public function show($owner, $name, $sha);
+
+    /**
+     * @param string $owner
+     * @param string $name
+     * @param array  $params
+     *
+     * @return Resource\Range
+     */
+    public function all($owner, $name, array $params = []);
+}

--- a/src/Repository/PullRequestRepository.php
+++ b/src/Repository/PullRequestRepository.php
@@ -16,7 +16,7 @@ namespace Localheinz\GitHub\ChangeLog\Repository;
 use Github\Api;
 use Localheinz\GitHub\ChangeLog\Resource;
 
-class PullRequestRepository
+final class PullRequestRepository implements PullRequestRepositoryInterface
 {
     /**
      * @var Api\PullRequest
@@ -24,23 +24,16 @@ class PullRequestRepository
     private $api;
 
     /**
-     * @var CommitRepository
+     * @var CommitRepositoryInterface
      */
     private $commitRepository;
 
-    public function __construct(Api\PullRequest $api, CommitRepository $commitRepository)
+    public function __construct(Api\PullRequest $api, CommitRepositoryInterface $commitRepository)
     {
         $this->api = $api;
         $this->commitRepository = $commitRepository;
     }
 
-    /**
-     * @param string $owner
-     * @param string $name
-     * @param string $number
-     *
-     * @return null|Resource\PullRequestInterface
-     */
     public function show($owner, $name, $number)
     {
         $response = $this->api->show(
@@ -59,14 +52,6 @@ class PullRequestRepository
         );
     }
 
-    /**
-     * @param string      $owner
-     * @param string      $name
-     * @param string      $startReference
-     * @param null|string $endReference
-     *
-     * @return Resource\Range
-     */
     public function items($owner, $name, $startReference, $endReference = null)
     {
         $range = $this->commitRepository->items(

--- a/src/Repository/PullRequestRepositoryInterface.php
+++ b/src/Repository/PullRequestRepositoryInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/github-changelog
+ */
+
+namespace Localheinz\GitHub\ChangeLog\Repository;
+
+use Localheinz\GitHub\ChangeLog\Resource;
+
+interface PullRequestRepositoryInterface
+{
+    /**
+     * @param string $owner
+     * @param string $name
+     * @param string $number
+     *
+     * @return null|Resource\PullRequestInterface
+     */
+    public function show($owner, $name, $number);
+
+    /**
+     * @param string      $owner
+     * @param string      $name
+     * @param string      $startReference
+     * @param null|string $endReference
+     *
+     * @return Resource\Range
+     */
+    public function items($owner, $name, $startReference, $endReference = null);
+}

--- a/test/Unit/Console/GenerateCommandTest.php
+++ b/test/Unit/Console/GenerateCommandTest.php
@@ -450,11 +450,11 @@ final class GenerateCommandTest extends Framework\TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|Repository\PullRequestRepository
+     * @return \PHPUnit_Framework_MockObject_MockObject|Repository\PullRequestRepositoryInterface
      */
     private function createPullRequestRepositoryMock()
     {
-        return $this->createMock(Repository\PullRequestRepository::class);
+        return $this->createMock(Repository\PullRequestRepositoryInterface::class);
     }
 
     /**

--- a/test/Unit/Repository/CommitRepositoryTest.php
+++ b/test/Unit/Repository/CommitRepositoryTest.php
@@ -24,6 +24,16 @@ final class CommitRepositoryTest extends Framework\TestCase
 {
     use TestHelper;
 
+    public function testIsFinal()
+    {
+        $this->assertFinal(Repository\CommitRepository::class);
+    }
+
+    public function testImplementsCommitRepositoryInterface()
+    {
+        $this->assertImplements(Repository\CommitRepositoryInterface::class, Repository\CommitRepository::class);
+    }
+
     public function testShowReturnsCommitEntityWithShaAndMessageOnSuccess()
     {
         $faker = $this->getFaker();

--- a/test/Unit/Repository/PullRequestRepositoryTest.php
+++ b/test/Unit/Repository/PullRequestRepositoryTest.php
@@ -23,6 +23,16 @@ final class PullRequestRepositoryTest extends Framework\TestCase
 {
     use TestHelper;
 
+    public function testIsFinal()
+    {
+        $this->assertFinal(Repository\PullRequestRepository::class);
+    }
+
+    public function testImplementsPullRequestRepositoryInterface()
+    {
+        $this->assertImplements(Repository\PullRequestRepositoryInterface::class, Repository\PullRequestRepository::class);
+    }
+
     public function testShowReturnsPullRequestEntityWithIdAndTitleOnSuccess()
     {
         $faker = $this->getFaker();
@@ -389,11 +399,11 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|Repository\CommitRepository
+     * @return \PHPUnit_Framework_MockObject_MockObject|Repository\CommitRepositoryInterface
      */
     private function createCommitRepositoryMock()
     {
-        return $this->createMock(Repository\CommitRepository::class);
+        return $this->createMock(Repository\CommitRepositoryInterface::class);
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] extracts interfaces and marks implementing classes as `final`