### PR TITLE
Fix: Use identicalTo() instead of equalTo()

### DIFF
--- a/src/Repository/PullRequestRepository.php
+++ b/src/Repository/PullRequestRepository.php
@@ -68,7 +68,7 @@ final class PullRequestRepository implements PullRequestRepositoryInterface
                 return;
             }
 
-            $number = $matches['number'];
+            $number = (int) $matches['number'];
 
             $pullRequest = $this->show(
                 $owner,

--- a/test/Unit/Console/GenerateCommandTest.php
+++ b/test/Unit/Console/GenerateCommandTest.php
@@ -166,8 +166,8 @@ final class GenerateCommandTest extends Framework\TestCase
             ->expects($this->once())
             ->method('authenticate')
             ->with(
-                $this->equalTo($authToken),
-                $this->equalTo(Client::AUTH_HTTP_TOKEN)
+                $this->identicalTo($authToken),
+                $this->identicalTo(Client::AUTH_HTTP_TOKEN)
             );
 
         $pullRequestRepository = $this->createPullRequestRepositoryMock();
@@ -207,10 +207,10 @@ final class GenerateCommandTest extends Framework\TestCase
             ->expects($this->once())
             ->method('items')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($startReference),
-                $this->equalTo($endReference)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($startReference),
+                $this->identicalTo($endReference)
             )
             ->willReturn($this->createRangeMock([]));
 

--- a/test/Unit/Repository/CommitRepositoryTest.php
+++ b/test/Unit/Repository/CommitRepositoryTest.php
@@ -50,9 +50,9 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('show')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($sha)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($sha)
             )
             ->willReturn($this->response($expectedItem));
 
@@ -84,9 +84,9 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('show')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($sha)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($sha)
             )
             ->willReturn('failure');
 
@@ -115,8 +115,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('all')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
                 $this->arrayHasKeyAndValue('sha', $sha)
             )
             ->willReturn('snafu');
@@ -151,8 +151,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('all')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
                 $this->arrayHasKeyAndValue('per_page', 250)
             )
             ->willReturn($this->responseFromItems($expectedItems));
@@ -185,8 +185,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('all')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
                 $this->arrayHasKeyAndValue('per_page', $perPage)
             )
             ->willReturn($this->responseFromItems($expectedItems));
@@ -219,8 +219,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('all')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
                 $this->arrayHasKeyAndValue('sha', $sha)
             )
             ->willReturn($this->responseFromItems($expectedItems));
@@ -293,9 +293,9 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(0))
             ->method('show')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($startReference)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($startReference)
             )
             ->willReturn(null);
 
@@ -332,9 +332,9 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(0))
             ->method('show')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($startReference)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($startReference)
             )
             ->willReturn($this->response($this->commitItem()));
 
@@ -342,9 +342,9 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(1))
             ->method('show')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($endReference)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($endReference)
             )
             ->willReturn(null);
 
@@ -383,9 +383,9 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(0))
             ->method('show')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($startReference)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($startReference)
             )
             ->willReturn($this->response($startCommit));
 
@@ -395,9 +395,9 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(1))
             ->method('show')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($endReference)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($endReference)
             )
             ->willReturn($this->response($endCommit));
 
@@ -405,8 +405,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('all')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
                 $this->arrayHasKeyAndValue('sha', $endCommit->sha)
             );
 
@@ -436,9 +436,9 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('show')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($startReference)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($startReference)
             )
             ->willReturn($this->response($startCommit));
 
@@ -446,8 +446,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('all')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
                 $this->arrayNotHasKey('sha')
             );
 
@@ -478,9 +478,9 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(0))
             ->method('show')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($startReference)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($startReference)
             )
             ->willReturn($this->response($startCommit));
 
@@ -491,9 +491,9 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(1))
             ->method('show')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($endReference)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($endReference)
             )
             ->willReturn($this->response($endCommit));
 
@@ -521,8 +521,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('all')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
                 $this->arrayHasKeyAndValue('sha', $endCommit->sha)
             )
             ->willReturn($this->responseFromItems($segment));
@@ -574,9 +574,9 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(0))
             ->method('show')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($startReference)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($startReference)
             )
             ->willReturn($this->response($startCommit));
 
@@ -587,9 +587,9 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(1))
             ->method('show')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($endReference)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($endReference)
             )
             ->willReturn($this->response($endCommit));
 
@@ -631,8 +631,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(2))
             ->method('all')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
                 $this->arrayHasKeyAndValue('sha', $endCommit->sha)
             )
             ->willReturn($this->responseFromItems($firstSegment));
@@ -641,8 +641,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(3))
             ->method('all')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
                 $this->arrayHasKeyAndValue('sha', $firstCommitFromFirstSegment->sha)
             )
             ->willReturn($this->responseFromItems($secondSegment));

--- a/test/Unit/Repository/PullRequestRepositoryTest.php
+++ b/test/Unit/Repository/PullRequestRepositoryTest.php
@@ -48,9 +48,9 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('show')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($expectedItem->number)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($expectedItem->number)
             )
             ->willReturn($this->response($expectedItem));
 
@@ -85,9 +85,9 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('show')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($number)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($number)
             )
             ->willReturn('snafu');
 
@@ -126,10 +126,10 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('items')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($startReference),
-                $this->equalTo(null)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($startReference),
+                $this->identicalTo(null)
             )
             ->willReturn($range);
 
@@ -171,10 +171,10 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('items')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($startReference),
-                $this->equalTo($endReference)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($startReference),
+                $this->identicalTo($endReference)
             )
             ->willReturn($range);
 
@@ -224,10 +224,10 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('items')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($startReference),
-                $this->equalTo($endReference)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($startReference),
+                $this->identicalTo($endReference)
             )
             ->willReturn($range);
 
@@ -286,10 +286,10 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('items')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($startReference),
-                $this->equalTo($endReference)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($startReference),
+                $this->identicalTo($endReference)
             )
             ->willReturn($range);
 
@@ -299,9 +299,9 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('show')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($expectedItem->number)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($expectedItem->number)
             )
             ->willReturn($this->response($expectedItem));
 
@@ -358,10 +358,10 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('items')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($startReference),
-                $this->equalTo($endReference)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($startReference),
+                $this->identicalTo($endReference)
             )
             ->willReturn($range);
 
@@ -371,9 +371,9 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('show')
             ->with(
-                $this->equalTo($owner),
-                $this->equalTo($name),
-                $this->equalTo($number)
+                $this->identicalTo($owner),
+                $this->identicalTo($name),
+                $this->identicalTo($number)
             )
             ->willReturn(null);
 


### PR DESCRIPTION
This PR

* [x] uses `identicalTo()` instead of `equalTo()` to ensure stricter constraints
* [x] casts the pull request number to `int` after matching