### PR TITLE
Fix: Use appropriate formatting

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -171,7 +171,7 @@ class GenerateCommand extends Command
             $io->newLine();
 
             $io->success(\sprintf(
-                'Found %s pull request%s.',
+                'Found %d pull request%s.',
                 \count($pullRequests),
                 1 === \count($pullRequests) ? '' : 's'
             ));

--- a/test/Unit/Console/GenerateCommandTest.php
+++ b/test/Unit/Console/GenerateCommandTest.php
@@ -316,7 +316,7 @@ final class GenerateCommandTest extends Framework\TestCase
 
         $expectedMessages = [
             \sprintf(
-                'Found %s pull requests',
+                'Found %d pull requests',
                 \count($pullRequests)
             ),
         ];
@@ -376,7 +376,7 @@ final class GenerateCommandTest extends Framework\TestCase
         $pullRequests = $this->pullRequests($count);
 
         $expectedMessage = \sprintf(
-            'Found %s pull requests',
+            'Found %d pull requests',
             \count($pullRequests)
         );
 

--- a/test/Unit/Repository/PullRequestRepositoryTest.php
+++ b/test/Unit/Repository/PullRequestRepositoryTest.php
@@ -260,7 +260,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         $mergeCommit = new Resource\Commit(
             $faker->unique()->sha1,
             \sprintf(
-                'Merge pull request #%s from localheinz/fix/directory',
+                'Merge pull request #%d from localheinz/fix/directory',
                 $expectedItem->number
             )
         );
@@ -336,7 +336,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         $mergeCommit = new Resource\Commit(
             $faker->sha1,
             \sprintf(
-                'Merge pull request #%s from localheinz/fix/directory',
+                'Merge pull request #%d from localheinz/fix/directory',
                 $number
             )
         );


### PR DESCRIPTION
This PR

* [x] uses appropriate formatting when using `sprintf()`