### PR TITLE
Fix: Pull request number should be an integer

### DIFF
--- a/src/Repository/PullRequestRepositoryInterface.php
+++ b/src/Repository/PullRequestRepositoryInterface.php
@@ -20,7 +20,7 @@ interface PullRequestRepositoryInterface
     /**
      * @param string $owner
      * @param string $name
-     * @param string $number
+     * @param int    $number
      *
      * @return null|Resource\PullRequestInterface
      */

--- a/src/Resource/PullRequest.php
+++ b/src/Resource/PullRequest.php
@@ -18,7 +18,7 @@ use Assert;
 final class PullRequest implements PullRequestInterface
 {
     /**
-     * @var string
+     * @var int
      */
     private $number;
 
@@ -28,14 +28,14 @@ final class PullRequest implements PullRequestInterface
     private $title;
 
     /**
-     * @param string $number
+     * @param int    $number
      * @param string $title
      *
      * @throws \InvalidArgumentException
      */
     public function __construct($number, $title)
     {
-        Assert\that($number)->integerish()->greaterThan(0);
+        Assert\that($number)->integer()->greaterThan(0);
         Assert\that($title)->string();
 
         $this->number = $number;

--- a/src/Resource/PullRequestInterface.php
+++ b/src/Resource/PullRequestInterface.php
@@ -16,7 +16,7 @@ namespace Localheinz\GitHub\ChangeLog\Resource;
 interface PullRequestInterface
 {
     /**
-     * @return string
+     * @return int
      */
     public function number();
 

--- a/test/Unit/Resource/PullRequestTest.php
+++ b/test/Unit/Resource/PullRequestTest.php
@@ -52,7 +52,7 @@ final class PullRequestTest extends Framework\TestCase
     public function providerInvalidNumber(): \Generator
     {
         return $this->provideDataFrom(
-            new DataProvider\InvalidIntegerish(),
+            new DataProvider\InvalidInteger(),
             new DataProvider\Elements([
                 0,
                 -1 * $this->getFaker()->numberBetween(1),


### PR DESCRIPTION
This PR

* [x] ensures that pull request number is an `int`

Follows #179.
Follows #187.