### PR TITLE
Enhancement: Throw PullRequestNotFound exception if pull request was not found

### DIFF
--- a/src/Exception/PullRequestNotFound.php
+++ b/src/Exception/PullRequestNotFound.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/github-changelog
+ */
+
+namespace Localheinz\GitHub\ChangeLog\Exception;
+
+final class PullRequestNotFound extends \RuntimeException implements ExceptionInterface
+{
+    public static function fromOwnerNameAndNumber(string $owner, string $name, int $number): self
+    {
+        return new self(\sprintf(
+            'Could not find pull request "%d" in "%s/%s".',
+            $number,
+            $owner,
+            $name
+        ));
+    }
+}

--- a/src/Repository/PullRequestRepository.php
+++ b/src/Repository/PullRequestRepository.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Localheinz\GitHub\ChangeLog\Repository;
 
 use Github\Api;
+use Localheinz\GitHub\ChangeLog\Exception;
 use Localheinz\GitHub\ChangeLog\Resource;
 
 final class PullRequestRepository implements PullRequestRepositoryInterface
@@ -43,7 +44,11 @@ final class PullRequestRepository implements PullRequestRepositoryInterface
         );
 
         if (!\is_array($response)) {
-            return;
+            throw Exception\PullRequestNotFound::fromOwnerNameAndNumber(
+                $owner,
+                $name,
+                $number
+            );
         }
 
         return new Resource\PullRequest(
@@ -70,13 +75,13 @@ final class PullRequestRepository implements PullRequestRepositoryInterface
 
             $number = (int) $matches['number'];
 
-            $pullRequest = $this->show(
-                $owner,
-                $name,
-                $number
-            );
-
-            if (null === $pullRequest) {
+            try {
+                $pullRequest = $this->show(
+                    $owner,
+                    $name,
+                    $number
+                );
+            } catch (Exception\PullRequestNotFound $exception) {
                 return;
             }
 

--- a/src/Repository/PullRequestRepositoryInterface.php
+++ b/src/Repository/PullRequestRepositoryInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Localheinz\GitHub\ChangeLog\Repository;
 
+use Localheinz\GitHub\ChangeLog\Exception;
 use Localheinz\GitHub\ChangeLog\Resource;
 
 interface PullRequestRepositoryInterface
@@ -22,7 +23,9 @@ interface PullRequestRepositoryInterface
      * @param string $name
      * @param string $number
      *
-     * @return null|Resource\PullRequestInterface
+     * @throws Exception\PullRequestNotFound
+     *
+     * @return Resource\PullRequestInterface
      */
     public function show($owner, $name, $number);
 

--- a/test/Unit/Exception/PullRequestNotFoundTest.php
+++ b/test/Unit/Exception/PullRequestNotFoundTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/github-changelog
+ */
+
+namespace Localheinz\GitHub\ChangeLog\Test\Unit\Exception;
+
+use Localheinz\GitHub\ChangeLog\Exception\ExceptionInterface;
+use Localheinz\GitHub\ChangeLog\Exception\PullRequestNotFound;
+use PHPUnit\Framework;
+use Refinery29\Test\Util\TestHelper;
+
+final class PullRequestNotFoundTest extends Framework\TestCase
+{
+    use TestHelper;
+
+    public function testIsFinal()
+    {
+        $this->assertFinal(PullRequestNotFound::class);
+    }
+
+    public function testExtendsRuntimeException()
+    {
+        $this->assertExtends(\RuntimeException::class, PullRequestNotFound::class);
+    }
+
+    public function testImplementsExceptionInterface()
+    {
+        $this->assertImplements(ExceptionInterface::class, PullRequestNotFound::class);
+    }
+
+    public function testFromOwnerRepositoryAndReferenceCreatesException()
+    {
+        $faker = $this->getFaker();
+
+        $owner = $faker->userName;
+        $name = $faker->slug();
+        $number = $faker->randomNumber();
+
+        $exception = PullRequestNotFound::fromOwnerNameAndNumber(
+            $owner,
+            $name,
+            $number
+        );
+
+        $this->assertInstanceOf(PullRequestNotFound::class, $exception);
+
+        $message = \sprintf(
+            'Could not find pull request "%s" in "%s/%s".',
+            $number,
+            $owner,
+            $name
+        );
+
+        $this->assertSame($message, $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+    }
+}

--- a/test/Unit/Repository/PullRequestRepositoryTest.php
+++ b/test/Unit/Repository/PullRequestRepositoryTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Localheinz\GitHub\ChangeLog\Test\Unit\Repository;
 
 use Github\Api;
+use Localheinz\GitHub\ChangeLog\Exception;
 use Localheinz\GitHub\ChangeLog\Repository;
 use Localheinz\GitHub\ChangeLog\Resource;
 use PHPUnit\Framework;
@@ -71,7 +72,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         $this->assertSame($expectedItem->title, $pullRequest->title());
     }
 
-    public function testShowReturnsNullOnFailure()
+    public function testShowThrowsPullRequestNotFoundOnFailure()
     {
         $faker = $this->getFaker();
 
@@ -96,13 +97,19 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             $this->createCommitRepositoryMock()
         );
 
-        $pullRequest = $pullRequestRepository->show(
+        $this->expectException(Exception\PullRequestNotFound::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Could not find pull request "%d" in "%s/%s".',
+            $number,
+            $owner,
+            $name
+        ));
+
+        $pullRequestRepository->show(
             $owner,
             $name,
             $number
         );
-
-        $this->assertNull($pullRequest);
     }
 
     public function testItemsDoesNotRequireAnEndReference()


### PR DESCRIPTION
This PR

* [x] throws a `PullRequestNotFound` exception if pull request was not found

Related to #177.