### PR TITLE
Fix: Drop argument equal to default

### DIFF
--- a/test/Unit/Console/GenerateCommandTest.php
+++ b/test/Unit/Console/GenerateCommandTest.php
@@ -212,7 +212,7 @@ final class GenerateCommandTest extends Framework\TestCase
                 $this->identicalTo($startReference),
                 $this->identicalTo($endReference)
             )
-            ->willReturn($this->createRangeMock([]));
+            ->willReturn($this->createRangeMock());
 
         $command = new Console\GenerateCommand(
             $this->createClientMock(),


### PR DESCRIPTION
This PR

* [x] drops an argument that is equal to the default value