### PR TITLE
Enhancement: Use localheinz/test-util

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
     "require-dev": {
         "codeclimate/php-test-reporter": "0.4.4",
         "localheinz/php-cs-fixer-config": "~1.6.2",
-        "phpunit/phpunit": "^6.4.1",
-        "refinery29/test-util": "0.9.6"
+        "localheinz/test-util": "0.4.0",
+        "phpunit/phpunit": "^6.4.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "272293b91bd3ef2db0f3b2cd0f02fa0b",
+    "content-hash": "b187626ecf566d3a63c1a9df4c8d9cc3",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -1701,29 +1701,31 @@
         },
         {
             "name": "fzaninotto/faker",
-            "version": "v1.6.0",
+            "version": "v1.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123"
+                "reference": "d3ed4cc37051c1ca52d22d76b437d14809fc7e0d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/44f9a286a04b80c76a4e5fb7aad8bb539b920123",
-                "reference": "44f9a286a04b80c76a4e5fb7aad8bb539b920123",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/d3ed4cc37051c1ca52d22d76b437d14809fc7e0d",
+                "reference": "d3ed4cc37051c1ca52d22d76b437d14809fc7e0d",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3|^7.0"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
                 "ext-intl": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~1.5"
+                "phpunit/phpunit": "^4.0 || ^5.0",
+                "squizlabs/php_codesniffer": "^1.5"
             },
             "type": "library",
             "extra": {
-                "branch-alias": []
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
             },
             "autoload": {
                 "psr-4": {
@@ -1745,7 +1747,7 @@
                 "faker",
                 "fixtures"
             ],
-            "time": "2016-04-29T12:21:54+00:00"
+            "time": "2017-08-15T16:48:10+00:00"
         },
         {
             "name": "gecko-packages/gecko-php-unit",
@@ -1885,6 +1887,49 @@
             "time": "2014-01-28T22:29:15+00:00"
         },
         {
+            "name": "localheinz/classy",
+            "version": "0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/localheinz/classy.git",
+                "reference": "165395d7e62bc49cf8c8bdd6d4e452fa367dbb31"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/localheinz/classy/zipball/165395d7e62bc49cf8c8bdd6d4e452fa367dbb31",
+                "reference": "165395d7e62bc49cf8c8bdd6d4e452fa367dbb31",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "0.4.4",
+                "localheinz/php-cs-fixer-config": "~1.6.2",
+                "localheinz/test-util": "0.2.2",
+                "phpbench/phpbench": "0.13.0",
+                "phpunit/phpunit": "^6.4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Localheinz\\Classy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides a way to collect classy constructs from source or a directory.",
+            "time": "2017-10-10T06:43:55+00:00"
+        },
+        {
             "name": "localheinz/php-cs-fixer-config",
             "version": "1.6.2",
             "source": {
@@ -1924,6 +1969,55 @@
             ],
             "description": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
             "time": "2017-10-02T12:24:21+00:00"
+        },
+        {
+            "name": "localheinz/test-util",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/localheinz/test-util.git",
+                "reference": "491a9d125681ef398ab9dbf5eb8c74164f456f20"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/localheinz/test-util/zipball/491a9d125681ef398ab9dbf5eb8c74164f456f20",
+                "reference": "491a9d125681ef398ab9dbf5eb8c74164f456f20",
+                "shasum": ""
+            },
+            "require": {
+                "fzaninotto/faker": "^1.7.1",
+                "localheinz/classy": "0.2.0",
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "0.4.4",
+                "localheinz/php-cs-fixer-config": "~1.6.2",
+                "phpunit/phpunit": "^6.3.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Localheinz\\Test\\Util\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides utilities for tests.",
+            "keywords": [
+                "assertion",
+                "faker",
+                "phpunit",
+                "test"
+            ],
+            "time": "2017-10-22T12:16:23+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2874,62 +2968,6 @@
                 "xunit"
             ],
             "time": "2017-08-03T14:08:16+00:00"
-        },
-        {
-            "name": "refinery29/test-util",
-            "version": "0.9.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/refinery29/test-util.git",
-                "reference": "08d085b4248f763a9ec974526a16f72858960455"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/refinery29/test-util/zipball/08d085b4248f763a9ec974526a16f72858960455",
-                "reference": "08d085b4248f763a9ec974526a16f72858960455",
-                "shasum": ""
-            },
-            "require": {
-                "fzaninotto/faker": "^1.6.0",
-                "php": "^5.6 || ^7.0"
-            },
-            "require-dev": {
-                "beberlei/assert": "^2.6.5",
-                "codeclimate/php-test-reporter": "0.3.2",
-                "phpunit/phpunit": "^5.6.1",
-                "refinery29/php-cs-fixer-config": "0.6.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Refinery29\\Test\\Util\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Andreas Möller",
-                    "email": "andreas.moller@refinery29.com"
-                },
-                {
-                    "name": "R29 Product & Engineering",
-                    "email": "p.e@refinery29.com"
-                },
-                {
-                    "name": "Graham Daniels",
-                    "email": "graham.daniels@refinery29.com"
-                }
-            ],
-            "description": "Provides a test helper, generic data providers, and assertions.",
-            "keywords": [
-                "faker",
-                "test",
-                "util"
-            ],
-            "time": "2016-12-08T12:47:21+00:00"
         },
         {
             "name": "satooshi/php-coveralls",

--- a/test/Unit/Console/GenerateCommandTest.php
+++ b/test/Unit/Console/GenerateCommandTest.php
@@ -17,14 +17,14 @@ use Github\Client;
 use Localheinz\GitHub\ChangeLog\Console;
 use Localheinz\GitHub\ChangeLog\Repository;
 use Localheinz\GitHub\ChangeLog\Resource;
+use Localheinz\Test\Util\Helper;
 use PHPUnit\Framework;
-use Refinery29\Test\Util\TestHelper;
 use Symfony\Component\Console\Input;
 use Symfony\Component\Console\Tester\CommandTester;
 
 final class GenerateCommandTest extends Framework\TestCase
 {
-    use TestHelper;
+    use Helper;
 
     public function testHasName()
     {
@@ -158,7 +158,7 @@ final class GenerateCommandTest extends Framework\TestCase
 
     public function testExecuteAuthenticatesIfTokenOptionIsGiven()
     {
-        $authToken = $this->getFaker()->password();
+        $authToken = $this->faker()->password();
 
         $client = $this->createClientMock();
 
@@ -194,7 +194,7 @@ final class GenerateCommandTest extends Framework\TestCase
 
     public function testExecuteDelegatesToPullRequestRepository()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->unique()->userName;
         $name = $faker->unique()->slug();
@@ -231,7 +231,7 @@ final class GenerateCommandTest extends Framework\TestCase
 
     public function testExecuteRendersMessageIfNoPullRequestsWereFound()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -267,7 +267,7 @@ final class GenerateCommandTest extends Framework\TestCase
 
     public function testExecuteRendersDifferentMessageIfNoPullRequestsWereFoundAndNoEndReferenceWasGiven()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -302,7 +302,7 @@ final class GenerateCommandTest extends Framework\TestCase
 
     public function testExecuteRendersPullRequestsWithTemplate()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -366,7 +366,7 @@ final class GenerateCommandTest extends Framework\TestCase
 
     public function testExecuteRendersDifferentMessageWhenNoEndReferenceWasGiven()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -407,7 +407,7 @@ final class GenerateCommandTest extends Framework\TestCase
 
     public function testExecuteHandlesExceptionsThrownWhenFetchingPullRequests()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $exception = new \Exception('Wait, this should not happen!');
 
@@ -476,7 +476,7 @@ final class GenerateCommandTest extends Framework\TestCase
 
     private function pullRequest(): Resource\PullRequestInterface
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $number = $faker->unique()->numberBetween(1);
         $title = $faker->unique()->sentence();

--- a/test/Unit/Exception/PullRequestNotFoundTest.php
+++ b/test/Unit/Exception/PullRequestNotFoundTest.php
@@ -15,31 +15,31 @@ namespace Localheinz\GitHub\ChangeLog\Test\Unit\Exception;
 
 use Localheinz\GitHub\ChangeLog\Exception\ExceptionInterface;
 use Localheinz\GitHub\ChangeLog\Exception\PullRequestNotFound;
+use Localheinz\Test\Util\Helper;
 use PHPUnit\Framework;
-use Refinery29\Test\Util\TestHelper;
 
 final class PullRequestNotFoundTest extends Framework\TestCase
 {
-    use TestHelper;
+    use Helper;
 
     public function testIsFinal()
     {
-        $this->assertFinal(PullRequestNotFound::class);
+        $this->assertClassIsFinal(PullRequestNotFound::class);
     }
 
     public function testExtendsRuntimeException()
     {
-        $this->assertExtends(\RuntimeException::class, PullRequestNotFound::class);
+        $this->assertClassExtends(\RuntimeException::class, PullRequestNotFound::class);
     }
 
     public function testImplementsExceptionInterface()
     {
-        $this->assertImplements(ExceptionInterface::class, PullRequestNotFound::class);
+        $this->assertClassImplementsInterface(ExceptionInterface::class, PullRequestNotFound::class);
     }
 
     public function testFromOwnerRepositoryAndReferenceCreatesException()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();

--- a/test/Unit/Exception/ReferenceNotFoundTest.php
+++ b/test/Unit/Exception/ReferenceNotFoundTest.php
@@ -15,31 +15,31 @@ namespace Localheinz\GitHub\ChangeLog\Test\Unit\Exception;
 
 use Localheinz\GitHub\ChangeLog\Exception\ExceptionInterface;
 use Localheinz\GitHub\ChangeLog\Exception\ReferenceNotFound;
+use Localheinz\Test\Util\Helper;
 use PHPUnit\Framework;
-use Refinery29\Test\Util\TestHelper;
 
 final class ReferenceNotFoundTest extends Framework\TestCase
 {
-    use TestHelper;
+    use Helper;
 
     public function testIsFinal()
     {
-        $this->assertFinal(ReferenceNotFound::class);
+        $this->assertClassIsFinal(ReferenceNotFound::class);
     }
 
     public function testExtendsRuntimeException()
     {
-        $this->assertExtends(\RuntimeException::class, ReferenceNotFound::class);
+        $this->assertClassExtends(\RuntimeException::class, ReferenceNotFound::class);
     }
 
     public function testImplementsExceptionInterface()
     {
-        $this->assertImplements(ExceptionInterface::class, ReferenceNotFound::class);
+        $this->assertClassImplementsInterface(ExceptionInterface::class, ReferenceNotFound::class);
     }
 
     public function testFromOwnerRepositoryAndReferenceCreatesException()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();

--- a/test/Unit/Repository/CommitRepositoryTest.php
+++ b/test/Unit/Repository/CommitRepositoryTest.php
@@ -17,26 +17,26 @@ use Github\Api;
 use Localheinz\GitHub\ChangeLog\Exception\ReferenceNotFound;
 use Localheinz\GitHub\ChangeLog\Repository;
 use Localheinz\GitHub\ChangeLog\Resource;
+use Localheinz\Test\Util\Helper;
 use PHPUnit\Framework;
-use Refinery29\Test\Util\TestHelper;
 
 final class CommitRepositoryTest extends Framework\TestCase
 {
-    use TestHelper;
+    use Helper;
 
     public function testIsFinal()
     {
-        $this->assertFinal(Repository\CommitRepository::class);
+        $this->assertClassIsFinal(Repository\CommitRepository::class);
     }
 
     public function testImplementsCommitRepositoryInterface()
     {
-        $this->assertImplements(Repository\CommitRepositoryInterface::class, Repository\CommitRepository::class);
+        $this->assertClassImplementsInterface(Repository\CommitRepositoryInterface::class, Repository\CommitRepository::class);
     }
 
     public function testShowReturnsCommitEntityWithShaAndMessageOnSuccess()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -72,7 +72,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
     public function testShowThrowsCommitNotFoundOnFailure()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -103,7 +103,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
     public function testAllReturnsEmptyArrayOnFailure()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -137,7 +137,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
     public function testAllSetsParamsPerPageTo250()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -170,7 +170,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
     public function testAllStillAllowsSettingPerPage()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -205,7 +205,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
     public function testAllReturnsRange()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -250,7 +250,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
     public function testItemsDoesNotFetchCommitsIfStartAndEndReferencesAreTheSame()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -280,7 +280,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
     public function testItemsDoesNotFetchCommitsIfStartCommitCouldNotBeFound()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -319,7 +319,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
     public function testItemsDoesNotFetchCommitsIfEndCommitCouldNotBeFound()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -368,7 +368,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
     public function testItemsFetchesCommitsUsingShaFromEndCommit()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -422,7 +422,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
     public function testItemsFetchesCommitsIfEndReferenceIsNotGiven()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -462,7 +462,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
     public function testItemsReturnsRangeOfCommitsFromEndToStartExcludingStart()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -558,7 +558,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
     public function testItemsFetchesMoreCommitsIfEndIsNotContainedInFirstBatch()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -686,7 +686,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
     private function commitItem(string $sha = null, string $message = null): \stdClass
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $data = new \stdClass();
 

--- a/test/Unit/Repository/PullRequestRepositoryTest.php
+++ b/test/Unit/Repository/PullRequestRepositoryTest.php
@@ -17,26 +17,26 @@ use Github\Api;
 use Localheinz\GitHub\ChangeLog\Exception;
 use Localheinz\GitHub\ChangeLog\Repository;
 use Localheinz\GitHub\ChangeLog\Resource;
+use Localheinz\Test\Util\Helper;
 use PHPUnit\Framework;
-use Refinery29\Test\Util\TestHelper;
 
 final class PullRequestRepositoryTest extends Framework\TestCase
 {
-    use TestHelper;
+    use Helper;
 
     public function testIsFinal()
     {
-        $this->assertFinal(Repository\PullRequestRepository::class);
+        $this->assertClassIsFinal(Repository\PullRequestRepository::class);
     }
 
     public function testImplementsPullRequestRepositoryInterface()
     {
-        $this->assertImplements(Repository\PullRequestRepositoryInterface::class, Repository\PullRequestRepository::class);
+        $this->assertClassImplementsInterface(Repository\PullRequestRepositoryInterface::class, Repository\PullRequestRepository::class);
     }
 
     public function testShowReturnsPullRequestEntityWithIdAndTitleOnSuccess()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -74,7 +74,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
 
     public function testShowThrowsPullRequestNotFoundOnFailure()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -114,7 +114,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
 
     public function testItemsDoesNotRequireAnEndReference()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -154,7 +154,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
 
     public function testItemsDoesNotTouchRangeIfNoCommitsWereFound()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -200,7 +200,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
 
     public function testItemsDoesNotTouchRangeIfNoMergeCommitsWereFound()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -253,7 +253,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
 
     public function testItemsFetchesPullRequestIfMergeCommitWasFound()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -329,7 +329,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
 
     public function testItemsHandlesMergeCommitWherePullRequestWasNotFound()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $owner = $faker->userName;
         $name = $faker->slug();
@@ -423,7 +423,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
 
     private function pullRequestItem(): \stdClass
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $item = new \stdClass();
 

--- a/test/Unit/Resource/AuthorTest.php
+++ b/test/Unit/Resource/AuthorTest.php
@@ -14,21 +14,21 @@ declare(strict_types=1);
 namespace Localheinz\GitHub\ChangeLog\Test\Unit\Resource;
 
 use Localheinz\GitHub\ChangeLog\Resource;
+use Localheinz\Test\Util\Helper;
 use PHPUnit\Framework;
-use Refinery29\Test\Util\TestHelper;
 
 final class AuthorTest extends Framework\TestCase
 {
-    use TestHelper;
+    use Helper;
 
     public function testIsFinal()
     {
-        $this->assertFinal(Resource\Author::class);
+        $this->assertClassIsFinal(Resource\Author::class);
     }
 
     public function testImplementsAuthorInterface()
     {
-        $this->assertImplements(Resource\AuthorInterface::class, Resource\Author::class);
+        $this->assertClassImplementsInterface(Resource\AuthorInterface::class, Resource\Author::class);
     }
 
     /**
@@ -40,7 +40,7 @@ final class AuthorTest extends Framework\TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        $login = $this->getFaker()->userName;
+        $login = $this->faker()->userName;
 
         new Resource\Author(
             $login,
@@ -50,7 +50,7 @@ final class AuthorTest extends Framework\TestCase
 
     public function providerInvalidHtmlUrl(): \Generator
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $values = [
             'string-path-only' => \implode('/', $faker->words),
@@ -66,7 +66,7 @@ final class AuthorTest extends Framework\TestCase
 
     public function testConstructorSetsLoginAndHtmlUrl()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $login = $faker->userName;
         $htmlUrl = $faker->url;

--- a/test/Unit/Resource/CommitTest.php
+++ b/test/Unit/Resource/CommitTest.php
@@ -14,21 +14,21 @@ declare(strict_types=1);
 namespace Localheinz\GitHub\ChangeLog\Test\Unit\Resource;
 
 use Localheinz\GitHub\ChangeLog\Resource;
+use Localheinz\Test\Util\Helper;
 use PHPUnit\Framework;
-use Refinery29\Test\Util\TestHelper;
 
 final class CommitTest extends Framework\TestCase
 {
-    use TestHelper;
+    use Helper;
 
     public function testIsFinal()
     {
-        $this->assertFinal(Resource\Commit::class);
+        $this->assertClassIsFinal(Resource\Commit::class);
     }
 
     public function testImplementsAuthorInterface()
     {
-        $this->assertImplements(Resource\CommitInterface::class, Resource\Commit::class);
+        $this->assertClassImplementsInterface(Resource\CommitInterface::class, Resource\Commit::class);
     }
 
     /**
@@ -40,7 +40,7 @@ final class CommitTest extends Framework\TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        $message = $this->getFaker()->sentence();
+        $message = $this->faker()->sentence();
 
         new Resource\Commit(
             $sha,
@@ -50,7 +50,7 @@ final class CommitTest extends Framework\TestCase
 
     public function providerInvalidSha(): \Generator
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $values = [
             'md5' => $faker->md5,
@@ -68,7 +68,7 @@ final class CommitTest extends Framework\TestCase
 
     public function testConstructorSetsShaAndMessage()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $sha = $faker->sha1;
         $message = $faker->sentence();
@@ -84,7 +84,7 @@ final class CommitTest extends Framework\TestCase
 
     public function testEqualsReturnsFalseIfHashesAreDifferent()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $one = new Resource\Commit(
             $faker->unique()->sha1,
@@ -101,7 +101,7 @@ final class CommitTest extends Framework\TestCase
 
     public function testEqualsReturnsTrueIfHashesAreTheSame()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $sha = $faker->sha1;
 

--- a/test/Unit/Resource/PullRequestTest.php
+++ b/test/Unit/Resource/PullRequestTest.php
@@ -14,21 +14,21 @@ declare(strict_types=1);
 namespace Localheinz\GitHub\ChangeLog\Test\Unit\Resource;
 
 use Localheinz\GitHub\ChangeLog\Resource;
+use Localheinz\Test\Util\Helper;
 use PHPUnit\Framework;
-use Refinery29\Test\Util\TestHelper;
 
 final class PullRequestTest extends Framework\TestCase
 {
-    use TestHelper;
+    use Helper;
 
     public function testIsFinal()
     {
-        $this->assertFinal(Resource\PullRequest::class);
+        $this->assertClassIsFinal(Resource\PullRequest::class);
     }
 
     public function testImplementsPullRequestInterface()
     {
-        $this->assertImplements(Resource\PullRequestInterface::class, Resource\PullRequest::class);
+        $this->assertClassImplementsInterface(Resource\PullRequestInterface::class, Resource\PullRequest::class);
     }
 
     /**
@@ -40,7 +40,7 @@ final class PullRequestTest extends Framework\TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        $title = $this->getFaker()->sentence();
+        $title = $this->faker()->sentence();
 
         new Resource\PullRequest(
             $number,
@@ -51,7 +51,7 @@ final class PullRequestTest extends Framework\TestCase
     public function providerInvalidNumber(): \Generator
     {
         $values = [
-            'int-negative' => -1 * $this->getFaker()->numberBetween(1),
+            'int-negative' => -1 * $this->faker()->numberBetween(1),
             'int-zero' => 0,
         ];
 
@@ -64,7 +64,7 @@ final class PullRequestTest extends Framework\TestCase
 
     public function testConstructorSetsIdAndTitle()
     {
-        $faker = $this->getFaker();
+        $faker = $this->faker();
 
         $number = $faker->numberBetween(1);
         $title = $faker->sentence();

--- a/test/Unit/Resource/RangeTest.php
+++ b/test/Unit/Resource/RangeTest.php
@@ -14,21 +14,21 @@ declare(strict_types=1);
 namespace Localheinz\GitHub\ChangeLog\Test\Unit\Resource;
 
 use Localheinz\GitHub\ChangeLog\Resource;
+use Localheinz\Test\Util\Helper;
 use PHPUnit\Framework;
-use Refinery29\Test\Util\TestHelper;
 
 final class RangeTest extends Framework\TestCase
 {
-    use TestHelper;
+    use Helper;
 
     public function testIsFinal()
     {
-        $this->assertFinal(Resource\Range::class);
+        $this->assertClassIsFinal(Resource\Range::class);
     }
 
     public function testImplementsRangeInterface()
     {
-        $this->assertImplements(Resource\RangeInterface::class, Resource\Range::class);
+        $this->assertClassImplementsInterface(Resource\RangeInterface::class, Resource\Range::class);
     }
 
     public function testDefaults()


### PR DESCRIPTION
This PR

* [x] uses `localheinz/test-util` instead of `refinery29/test-util`