### PR TITLE
Fix: Mark GenerateCommand as final

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\Stopwatch\StopwatchEvent;
 
-class GenerateCommand extends Command
+final class GenerateCommand extends Command
 {
     /**
      * @var Client

--- a/test/Unit/ProjectCodeTest.php
+++ b/test/Unit/ProjectCodeTest.php
@@ -23,9 +23,7 @@ final class ProjectCodeTest extends Framework\TestCase
 
     public function testProductionClassesAreAbstractOrFinal()
     {
-        $this->assertClassesAreAbstractOrFinal(__DIR__ . '/../../src', [
-            ChangeLog\Console\GenerateCommand::class,
-        ]);
+        $this->assertClassesAreAbstractOrFinal(__DIR__ . '/../../src');
     }
 
     public function testProductionClassesHaveTests()


### PR DESCRIPTION
This PR

* [x] marks `GenerateCommand` as `final`