### PR TITLE
Fix: Update description of GenerateCommand

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -54,7 +54,7 @@ final class GenerateCommand extends Command
     {
         $this
             ->setName('generate')
-            ->setDescription('Generates a changelog from information found between commit references')
+            ->setDescription('Generates a changelog from merged pull requests found between commit references')
             ->addArgument(
                 'owner',
                 Input\InputArgument::REQUIRED,

--- a/test/Unit/Console/GenerateCommandTest.php
+++ b/test/Unit/Console/GenerateCommandTest.php
@@ -43,7 +43,7 @@ final class GenerateCommandTest extends Framework\TestCase
             $this->createPullRequestRepositoryMock()
         );
 
-        $this->assertSame('Generates a changelog from information found between commit references', $command->getDescription());
+        $this->assertSame('Generates a changelog from merged pull requests found between commit references', $command->getDescription());
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] updates the description of the `GenerateCommand`