### PR TITLE
Fix: Account for single pull request count

### DIFF
--- a/test/Unit/Console/GenerateCommandTest.php
+++ b/test/Unit/Console/GenerateCommandTest.php
@@ -316,8 +316,9 @@ final class GenerateCommandTest extends Framework\TestCase
 
         $expectedMessages = [
             \sprintf(
-                'Found %d pull requests',
-                \count($pullRequests)
+                'Found %d pull request%s',
+                $count,
+                1 === $count ? '' : 's'
             ),
         ];
 
@@ -376,8 +377,9 @@ final class GenerateCommandTest extends Framework\TestCase
         $pullRequests = $this->pullRequests($count);
 
         $expectedMessage = \sprintf(
-            'Found %d pull requests',
-            \count($pullRequests)
+            'Found %d pull request%s',
+            $count,
+            1 === $count ? '' : 's'
         );
 
         $pullRequestRepository = $this->createPullRequestRepositoryMock();


### PR DESCRIPTION
This PR

* [x] accounts for a pull request count of `1` in tests