### PR TITLE
Fix: Use slug() instead of userName() generator

### DIFF
--- a/test/Unit/Console/GenerateCommandTest.php
+++ b/test/Unit/Console/GenerateCommandTest.php
@@ -196,7 +196,7 @@ final class GenerateCommandTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->unique()->userName;
+        $owner = $faker->unique()->slug();
         $name = $faker->unique()->slug();
         $startReference = $faker->unique()->sha1;
         $endReference = $faker->unique()->sha1;
@@ -233,7 +233,7 @@ final class GenerateCommandTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
@@ -269,7 +269,7 @@ final class GenerateCommandTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $startReference = $faker->sha1;
 
@@ -304,7 +304,7 @@ final class GenerateCommandTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
@@ -369,7 +369,7 @@ final class GenerateCommandTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $startReference = $faker->sha1;
         $count = $faker->numberBetween(1, 5);
@@ -433,7 +433,7 @@ final class GenerateCommandTest extends Framework\TestCase
         $tester = new CommandTester($command);
 
         $exitCode = $tester->execute([
-            'owner' => $faker->unique()->userName,
+            'owner' => $faker->unique()->slug(),
             'repository' => $faker->unique()->slug(),
             'start-reference' => $faker->unique()->sha1,
             'end-reference' => $faker->unique()->sha1,

--- a/test/Unit/Exception/PullRequestNotFoundTest.php
+++ b/test/Unit/Exception/PullRequestNotFoundTest.php
@@ -36,7 +36,7 @@ final class PullRequestNotFoundTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $number = $faker->randomNumber();
 

--- a/test/Unit/Exception/ReferenceNotFoundTest.php
+++ b/test/Unit/Exception/ReferenceNotFoundTest.php
@@ -36,7 +36,7 @@ final class ReferenceNotFoundTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $reference = $faker->sha1;
 

--- a/test/Unit/Repository/CommitRepositoryTest.php
+++ b/test/Unit/Repository/CommitRepositoryTest.php
@@ -33,7 +33,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $sha = $faker->sha1;
 
@@ -69,7 +69,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $sha = $faker->sha1;
 
@@ -100,7 +100,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $sha = $faker->sha1;
 
@@ -134,7 +134,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $sha = $faker->sha1;
 
@@ -167,7 +167,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $sha = $faker->sha1;
         $perPage = $faker->randomNumber();
@@ -202,7 +202,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $sha = $faker->sha1;
 
@@ -247,7 +247,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $startReference = $faker->sha1;
 
@@ -277,7 +277,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
@@ -316,7 +316,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
@@ -365,7 +365,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
@@ -419,7 +419,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $startReference = $faker->sha1;
 
@@ -459,7 +459,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
@@ -555,7 +555,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;

--- a/test/Unit/Repository/PullRequestRepositoryTest.php
+++ b/test/Unit/Repository/PullRequestRepositoryTest.php
@@ -33,7 +33,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
 
         $api = $this->createPullRequestApiMock();
@@ -71,7 +71,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $number = $faker->randomNumber();
 
@@ -111,7 +111,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $startReference = $faker->sha1;
 
@@ -151,7 +151,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
@@ -197,7 +197,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
@@ -250,7 +250,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
@@ -326,7 +326,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName;
+        $owner = $faker->slug();
         $name = $faker->slug();
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;

--- a/test/Unit/Resource/AuthorTest.php
+++ b/test/Unit/Resource/AuthorTest.php
@@ -35,7 +35,7 @@ final class AuthorTest extends Framework\TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        $login = $this->faker()->userName;
+        $login = $this->faker()->slug();
 
         new Resource\Author(
             $login,
@@ -63,7 +63,7 @@ final class AuthorTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $login = $faker->userName;
+        $login = $faker->slug();
         $htmlUrl = $faker->url;
 
         $author = new Resource\Author(

--- a/test/Unit/Resource/RepositoryTest.php
+++ b/test/Unit/Resource/RepositoryTest.php
@@ -96,7 +96,7 @@ final class RepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->userName();
+        $owner = $faker->slug();
 
         $this->expectException(\InvalidArgumentException::class);
 


### PR DESCRIPTION
This PR

* [x] uses the `slug()` instead of the `userName()` generator

Follows #197.

💁‍♂️ The generator creates user names that contain characters not accepted by GitHub. For consistency, it makes sense not to use such a generator, then.