### PR TITLE
Enhancement: Allow to represent repository as string

### DIFF
--- a/src/Resource/Repository.php
+++ b/src/Resource/Repository.php
@@ -42,6 +42,15 @@ final class Repository implements RepositoryInterface
         $this->name = $name;
     }
 
+    public function __toString(): string
+    {
+        return \sprintf(
+            '%s/%s',
+            $this->owner,
+            $this->name
+        );
+    }
+
     /**
      * @param string $string
      *

--- a/src/Resource/RepositoryInterface.php
+++ b/src/Resource/RepositoryInterface.php
@@ -15,6 +15,8 @@ namespace Localheinz\GitHub\ChangeLog\Resource;
 
 interface RepositoryInterface
 {
+    public function __toString(): string;
+
     public function owner(): string;
 
     public function name(): string;

--- a/test/Unit/Resource/RepositoryTest.php
+++ b/test/Unit/Resource/RepositoryTest.php
@@ -99,6 +99,27 @@ final class RepositoryTest extends Framework\TestCase
         $this->assertSame($name, $repository->name());
     }
 
+    public function testToStringReturnsStringRepresentation()
+    {
+        $faker = $this->faker();
+
+        $owner = $faker->slug();
+        $name = $faker->slug();
+
+        $repository = new Resource\Repository(
+            $owner,
+            $name
+        );
+
+        $expected = \sprintf(
+            '%s/%s',
+            $owner,
+            $name
+        );
+
+        $this->assertSame($expected, $repository->__toString());
+    }
+
     /**
      * @dataProvider providerInvalidString
      *


### PR DESCRIPTION
This PR

* [x] implements a `__toString()` method on the `Repository` resource