### PR TITLE
Fix: Use numberBetween(1) instead of randomNumber() generator

### DIFF
--- a/test/Unit/Exception/PullRequestNotFoundTest.php
+++ b/test/Unit/Exception/PullRequestNotFoundTest.php
@@ -38,7 +38,7 @@ final class PullRequestNotFoundTest extends Framework\TestCase
 
         $owner = $faker->slug();
         $name = $faker->slug();
-        $number = $faker->randomNumber();
+        $number = $faker->numberBetween(1);
 
         $exception = PullRequestNotFound::fromOwnerNameAndNumber(
             $owner,

--- a/test/Unit/Repository/CommitRepositoryTest.php
+++ b/test/Unit/Repository/CommitRepositoryTest.php
@@ -170,7 +170,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $owner = $faker->slug();
         $name = $faker->slug();
         $sha = $faker->sha1;
-        $perPage = $faker->randomNumber();
+        $perPage = $faker->numberBetween(1);
 
         $commitApi = $this->createCommitApiMock();
 

--- a/test/Unit/Repository/PullRequestRepositoryTest.php
+++ b/test/Unit/Repository/PullRequestRepositoryTest.php
@@ -73,7 +73,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
 
         $owner = $faker->slug();
         $name = $faker->slug();
-        $number = $faker->randomNumber();
+        $number = $faker->numberBetween(1);
 
         $api = $this->createPullRequestApiMock();
 
@@ -422,7 +422,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
 
         $item = new \stdClass();
 
-        $item->number = $faker->unique()->randomNumber();
+        $item->number = $faker->unique()->numberBetween(1);
         $item->title = $faker->unique()->sentence();
 
         return $item;

--- a/test/Unit/Resource/RepositoryTest.php
+++ b/test/Unit/Resource/RepositoryTest.php
@@ -261,7 +261,7 @@ final class RepositoryTest extends Framework\TestCase
             'word-with-numbers' => \sprintf(
                 '%s%d',
                 $faker->word,
-                $faker->randomNumber()
+                $faker->numberBetween(1)
             ),
             'words-separated-by-hyphen' => \implode(
                 '-',
@@ -270,8 +270,8 @@ final class RepositoryTest extends Framework\TestCase
             'words-with-numbers-separated-by-hyphens' => \implode(
                 '-',
                 \array_merge($faker->words(), [
-                    $faker->randomNumber(),
-                    $faker->randomNumber(),
+                    $faker->numberBetween(1),
+                    $faker->numberBetween(1),
                 ])
             ),
         ];
@@ -313,7 +313,7 @@ final class RepositoryTest extends Framework\TestCase
             'word-with-numbers' => \sprintf(
                 '%s%d',
                 $faker->word,
-                $faker->randomNumber()
+                $faker->numberBetween(1)
             ),
             'words-separated-by-hyphen' => \implode(
                 '-',
@@ -326,15 +326,15 @@ final class RepositoryTest extends Framework\TestCase
             'words-with-numbers-separated-by-hyphens' => \implode(
                 '-',
                 \array_merge($faker->words(), [
-                    $faker->randomNumber(),
-                    $faker->randomNumber(),
+                    $faker->numberBetween(1),
+                    $faker->numberBetween(1),
                 ])
             ),
             'words-with-numbers-separated-by-underscores' => \implode(
                 '_',
                 \array_merge($faker->words(), [
-                    $faker->randomNumber(),
-                    $faker->randomNumber(),
+                    $faker->numberBetween(1),
+                    $faker->numberBetween(1),
                 ])
             ),
         ];


### PR DESCRIPTION
This PR

* [x] uses the `numberBetween()` generator instead of `randomNumber()` to avoid `0`