### PR TITLE
Enhancement: Use repository resource instead of owner and name separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,15 +121,14 @@ $client->authenticate(
     Client::AUTH_HTTP_TOKEN
 );
 
-$repository = new Repository\PullRequestRepository(
+$pullRequestRepository = new Repository\PullRequestRepository(
     $client->pullRequests(),
     new Repository\CommitRepository($client->repositories()->commits())
 );
 
 /* @var Resource\RangeInterface $range */
 $range = $repository->items(
-    'localheinz',
-    'github-changelog',
+    Resource\Repository::fromString('localheinz/github-changelog'),
     '0.1.1',
     '0.1.2'
 );
@@ -138,7 +137,7 @@ $pullRequests = $range->pullRequests();
 
 array_walk($pullRequests, function (Resource\PullRequestInterface $pullRequest) {
     echo sprintf(
-        '- %s (#%s)' . PHP_EOL,
+        '- %s (#%d)' . PHP_EOL,
         $pullRequest->title(),
         $pullRequest->number()
     );

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -110,8 +110,21 @@ final class GenerateCommand extends Command
             );
         }
 
-        $owner = $input->getArgument('owner');
-        $name = $input->getArgument('repository');
+        try {
+            $repository = new Resource\Repository(
+                $input->getArgument('owner'),
+                $input->getArgument('repository')
+            );
+        } catch (\InvalidArgumentException $exception) {
+            $io->error(\sprintf(
+                'Owner "%s" and repository "%s" appear to be invalid.',
+                $input->getArgument('owner'),
+                $input->getArgument('repository')
+            ));
+
+            return 1;
+        }
+
         $startReference = $input->getArgument('start-reference');
         $endReference = $input->getArgument('end-reference');
 
@@ -121,16 +134,14 @@ final class GenerateCommand extends Command
         );
 
         $io->section(\sprintf(
-            'Pull Requests for %s/%s %s',
-            $owner,
-            $name,
+            'Pull Requests for %s %s',
+            $repository,
             $range
         ));
 
         try {
             $range = $this->pullRequestRepository->items(
-                $owner,
-                $name,
+                $repository,
                 $startReference,
                 $endReference
             );

--- a/src/Exception/PullRequestNotFound.php
+++ b/src/Exception/PullRequestNotFound.php
@@ -13,15 +13,16 @@ declare(strict_types=1);
 
 namespace Localheinz\GitHub\ChangeLog\Exception;
 
+use Localheinz\GitHub\ChangeLog\Resource;
+
 final class PullRequestNotFound extends \RuntimeException implements ExceptionInterface
 {
-    public static function fromOwnerNameAndNumber(string $owner, string $name, int $number): self
+    public static function fromRepositoryAndNumber(Resource\RepositoryInterface $repository, int $number): self
     {
         return new self(\sprintf(
-            'Could not find pull request "%d" in "%s/%s".',
+            'Could not find pull request "%d" in "%s".',
             $number,
-            $owner,
-            $name
+            $repository
         ));
     }
 }

--- a/src/Exception/ReferenceNotFound.php
+++ b/src/Exception/ReferenceNotFound.php
@@ -13,15 +13,16 @@ declare(strict_types=1);
 
 namespace Localheinz\GitHub\ChangeLog\Exception;
 
+use Localheinz\GitHub\ChangeLog\Resource;
+
 final class ReferenceNotFound extends \RuntimeException implements ExceptionInterface
 {
-    public static function fromOwnerNameAndReference(string $owner, string $name, string $reference): self
+    public static function fromRepositoryAndReference(Resource\RepositoryInterface $repository, string $reference): self
     {
         return new self(\sprintf(
-            'Could not find reference "%s" in "%s/%s".',
+            'Could not find reference "%s" in "%s".',
             $reference,
-            $owner,
-            $name
+            $repository
         ));
     }
 }

--- a/src/Repository/CommitRepositoryInterface.php
+++ b/src/Repository/CommitRepositoryInterface.php
@@ -19,32 +19,29 @@ use Localheinz\GitHub\ChangeLog\Resource;
 interface CommitRepositoryInterface
 {
     /**
-     * @param string      $owner
-     * @param string      $name
-     * @param string      $startReference
-     * @param null|string $endReference
+     * @param Resource\RepositoryInterface $repository
+     * @param string                       $startReference
+     * @param null|string                  $endReference
      *
      * @return Resource\RangeInterface
      */
-    public function items(string $owner, string $name, string $startReference, string $endReference = null): Resource\RangeInterface;
+    public function items(Resource\RepositoryInterface $repository, string $startReference, string $endReference = null): Resource\RangeInterface;
 
     /**
-     * @param string $owner
-     * @param string $name
-     * @param string $sha
+     * @param Resource\RepositoryInterface $repository
+     * @param string                       $sha
      *
      * @throws Exception\ReferenceNotFound
      *
      * @return Resource\CommitInterface
      */
-    public function show(string $owner, string $name, string $sha): Resource\CommitInterface;
+    public function show(Resource\RepositoryInterface $repository, string $sha): Resource\CommitInterface;
 
     /**
-     * @param string $owner
-     * @param string $name
-     * @param array  $params
+     * @param Resource\RepositoryInterface $repository
+     * @param array                        $params
      *
      * @return Resource\RangeInterface
      */
-    public function all(string $owner, string $name, array $params = []): Resource\RangeInterface;
+    public function all(Resource\RepositoryInterface $repository, array $params = []): Resource\RangeInterface;
 }

--- a/src/Repository/PullRequestRepositoryInterface.php
+++ b/src/Repository/PullRequestRepositoryInterface.php
@@ -19,23 +19,21 @@ use Localheinz\GitHub\ChangeLog\Resource;
 interface PullRequestRepositoryInterface
 {
     /**
-     * @param string $owner
-     * @param string $name
-     * @param int    $number
+     * @param Resource\RepositoryInterface$repository
+     * @param int $number
      *
      * @throws Exception\PullRequestNotFound
      *
      * @return Resource\PullRequestInterface
      */
-    public function show(string $owner, string $name, int $number): Resource\PullRequestInterface;
+    public function show(Resource\RepositoryInterface $repository, int $number): Resource\PullRequestInterface;
 
     /**
-     * @param string      $owner
-     * @param string      $name
+     * @param Resource\RepositoryInterface$repository
      * @param string      $startReference
      * @param null|string $endReference
      *
      * @return Resource\RangeInterface
      */
-    public function items(string $owner, string $name, string $startReference, string $endReference = null): Resource\RangeInterface;
+    public function items(Resource\RepositoryInterface $repository, string $startReference, string $endReference = null): Resource\RangeInterface;
 }

--- a/test/Unit/Exception/PullRequestNotFoundTest.php
+++ b/test/Unit/Exception/PullRequestNotFoundTest.php
@@ -15,6 +15,7 @@ namespace Localheinz\GitHub\ChangeLog\Test\Unit\Exception;
 
 use Localheinz\GitHub\ChangeLog\Exception\ExceptionInterface;
 use Localheinz\GitHub\ChangeLog\Exception\PullRequestNotFound;
+use Localheinz\GitHub\ChangeLog\Resource;
 use Localheinz\Test\Util\Helper;
 use PHPUnit\Framework;
 
@@ -32,27 +33,28 @@ final class PullRequestNotFoundTest extends Framework\TestCase
         $this->assertClassImplementsInterface(ExceptionInterface::class, PullRequestNotFound::class);
     }
 
-    public function testFromOwnerRepositoryAndReferenceCreatesException()
+    public function testFromRepositoryAndNumberCreatesException()
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
         $number = $faker->numberBetween(1);
 
-        $exception = PullRequestNotFound::fromOwnerNameAndNumber(
-            $owner,
-            $name,
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
+
+        $exception = PullRequestNotFound::fromRepositoryAndNumber(
+            $repository,
             $number
         );
 
         $this->assertInstanceOf(PullRequestNotFound::class, $exception);
 
         $message = \sprintf(
-            'Could not find pull request "%s" in "%s/%s".',
+            'Could not find pull request "%s" in "%s".',
             $number,
-            $owner,
-            $name
+            $repository
         );
 
         $this->assertSame($message, $exception->getMessage());

--- a/test/Unit/Exception/ReferenceNotFoundTest.php
+++ b/test/Unit/Exception/ReferenceNotFoundTest.php
@@ -15,6 +15,7 @@ namespace Localheinz\GitHub\ChangeLog\Test\Unit\Exception;
 
 use Localheinz\GitHub\ChangeLog\Exception\ExceptionInterface;
 use Localheinz\GitHub\ChangeLog\Exception\ReferenceNotFound;
+use Localheinz\GitHub\ChangeLog\Resource;
 use Localheinz\Test\Util\Helper;
 use PHPUnit\Framework;
 
@@ -32,27 +33,28 @@ final class ReferenceNotFoundTest extends Framework\TestCase
         $this->assertClassImplementsInterface(ExceptionInterface::class, ReferenceNotFound::class);
     }
 
-    public function testFromOwnerRepositoryAndReferenceCreatesException()
+    public function testFromRepositoryAndReferenceCreatesException()
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
+
         $reference = $faker->sha1;
 
-        $exception = ReferenceNotFound::fromOwnerNameAndReference(
-            $owner,
-            $name,
+        $exception = ReferenceNotFound::fromRepositoryAndReference(
+            $repository,
             $reference
         );
 
         $this->assertInstanceOf(ReferenceNotFound::class, $exception);
 
         $message = \sprintf(
-            'Could not find reference "%s" in "%s/%s".',
+            'Could not find reference "%s" in "%s".',
             $reference,
-            $owner,
-            $name
+            $repository
         );
 
         $this->assertSame($message, $exception->getMessage());

--- a/test/Unit/Repository/CommitRepositoryTest.php
+++ b/test/Unit/Repository/CommitRepositoryTest.php
@@ -33,8 +33,11 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
+
         $sha = $faker->sha1;
 
         $commitApi = $this->createCommitApiMock();
@@ -45,8 +48,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('show')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->identicalTo($sha)
             )
             ->willReturn($this->response($expectedItem));
@@ -54,8 +57,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $commitRepository = new Repository\CommitRepository($commitApi);
 
         $commit = $commitRepository->show(
-            $owner,
-            $name,
+            $repository,
             $sha
         );
 
@@ -69,8 +71,11 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
+
         $sha = $faker->sha1;
 
         $api = $this->createCommitApiMock();
@@ -79,8 +84,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('show')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->identicalTo($sha)
             )
             ->willReturn('failure');
@@ -90,8 +95,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $this->expectException(ReferenceNotFound::class);
 
         $commitRepository->show(
-            $owner,
-            $name,
+            $repository,
             $sha
         );
     }
@@ -100,8 +104,11 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
+
         $sha = $faker->sha1;
 
         $commitApi = $this->createCommitApiMock();
@@ -110,21 +117,17 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('all')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->arrayHasKeyAndValue('sha', $sha)
             )
             ->willReturn('snafu');
 
         $commitRepository = new Repository\CommitRepository($commitApi);
 
-        $range = $commitRepository->all(
-            $owner,
-            $name,
-            [
-                'sha' => $sha,
-            ]
-        );
+        $range = $commitRepository->all($repository, [
+            'sha' => $sha,
+        ]);
 
         $this->assertInstanceOf(Resource\Range::class, $range);
         $this->assertCount(0, $range->commits());
@@ -134,8 +137,11 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
+
         $sha = $faker->sha1;
 
         $commitApi = $this->createCommitApiMock();
@@ -146,29 +152,28 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('all')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->arrayHasKeyAndValue('per_page', 250)
             )
             ->willReturn($this->responseFromItems($expectedItems));
 
         $commitRepository = new Repository\CommitRepository($commitApi);
 
-        $commitRepository->all(
-            $owner,
-            $name,
-            [
-                'sha' => $sha,
-            ]
-        );
+        $commitRepository->all($repository, [
+            'sha' => $sha,
+        ]);
     }
 
     public function testAllStillAllowsSettingPerPage()
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
+
         $sha = $faker->sha1;
         $perPage = $faker->numberBetween(1);
 
@@ -180,30 +185,29 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('all')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->arrayHasKeyAndValue('per_page', $perPage)
             )
             ->willReturn($this->responseFromItems($expectedItems));
 
         $commitRepository = new Repository\CommitRepository($commitApi);
 
-        $commitRepository->all(
-            $owner,
-            $name,
-            [
-                'sha' => $sha,
-                'per_page' => $perPage,
-            ]
-        );
+        $commitRepository->all($repository, [
+            'sha' => $sha,
+            'per_page' => $perPage,
+        ]);
     }
 
     public function testAllReturnsRange()
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
+
         $sha = $faker->sha1;
 
         $commitApi = $this->createCommitApiMock();
@@ -214,15 +218,15 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('all')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->arrayHasKeyAndValue('sha', $sha)
             )
             ->willReturn($this->responseFromItems($expectedItems));
 
         $commitRepository = new Repository\CommitRepository($commitApi);
 
-        $range = $commitRepository->all($owner, $name, [
+        $range = $commitRepository->all($repository, [
             'sha' => $sha,
         ]);
 
@@ -247,8 +251,11 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
+
         $startReference = $faker->sha1;
 
         $endReference = $startReference;
@@ -262,8 +269,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $commitRepository = new Repository\CommitRepository($commitApi);
 
         $range = $commitRepository->items(
-            $owner,
-            $name,
+            $repository,
             $startReference,
             $endReference
         );
@@ -277,8 +283,11 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
+
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
@@ -288,8 +297,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(0))
             ->method('show')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->identicalTo($startReference)
             )
             ->willReturn(null);
@@ -301,8 +310,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $commitRepository = new Repository\CommitRepository($commitApi);
 
         $range = $commitRepository->items(
-            $owner,
-            $name,
+            $repository,
             $startReference,
             $endReference
         );
@@ -316,8 +324,11 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
+
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
@@ -327,8 +338,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(0))
             ->method('show')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->identicalTo($startReference)
             )
             ->willReturn($this->response($this->commitItem()));
@@ -337,8 +348,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(1))
             ->method('show')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->identicalTo($endReference)
             )
             ->willReturn(null);
@@ -350,8 +361,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $commitRepository = new Repository\CommitRepository($commitApi);
 
         $range = $commitRepository->items(
-            $owner,
-            $name,
+            $repository,
             $startReference,
             $endReference
         );
@@ -365,8 +375,11 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
+
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
@@ -378,8 +391,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(0))
             ->method('show')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->identicalTo($startReference)
             )
             ->willReturn($this->response($startCommit));
@@ -390,8 +403,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(1))
             ->method('show')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->identicalTo($endReference)
             )
             ->willReturn($this->response($endCommit));
@@ -400,16 +413,15 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('all')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->arrayHasKeyAndValue('sha', $endCommit->sha)
             );
 
         $commitRepository = new Repository\CommitRepository($commitApi);
 
         $commitRepository->items(
-            $owner,
-            $name,
+            $repository,
             $startReference,
             $endReference
         );
@@ -419,8 +431,11 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
+
         $startReference = $faker->sha1;
 
         $commitApi = $this->createCommitApiMock();
@@ -431,8 +446,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('show')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->identicalTo($startReference)
             )
             ->willReturn($this->response($startCommit));
@@ -441,16 +456,15 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('all')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->arrayNotHasKey('sha')
             );
 
         $commitRepository = new Repository\CommitRepository($commitApi);
 
         $commitRepository->items(
-            $owner,
-            $name,
+            $repository,
             $startReference
         );
     }
@@ -459,8 +473,11 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
+
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
@@ -473,8 +490,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(0))
             ->method('show')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->identicalTo($startReference)
             )
             ->willReturn($this->response($startCommit));
@@ -486,8 +503,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(1))
             ->method('show')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->identicalTo($endReference)
             )
             ->willReturn($this->response($endCommit));
@@ -516,8 +533,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('all')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->arrayHasKeyAndValue('sha', $endCommit->sha)
             )
             ->willReturn($this->responseFromItems($segment));
@@ -525,8 +542,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $commitRepository = new Repository\CommitRepository($commitApi);
 
         $range = $commitRepository->items(
-            $owner,
-            $name,
+            $repository,
             $startReference,
             $endReference
         );
@@ -555,8 +571,11 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
+
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
@@ -569,8 +588,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(0))
             ->method('show')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->identicalTo($startReference)
             )
             ->willReturn($this->response($startCommit));
@@ -582,8 +601,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(1))
             ->method('show')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->identicalTo($endReference)
             )
             ->willReturn($this->response($endCommit));
@@ -626,8 +645,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(2))
             ->method('all')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->arrayHasKeyAndValue('sha', $endCommit->sha)
             )
             ->willReturn($this->responseFromItems($firstSegment));
@@ -636,8 +655,8 @@ final class CommitRepositoryTest extends Framework\TestCase
             ->expects($this->at(3))
             ->method('all')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->arrayHasKeyAndValue('sha', $firstCommitFromFirstSegment->sha)
             )
             ->willReturn($this->responseFromItems($secondSegment));
@@ -645,8 +664,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         $commitRepository = new Repository\CommitRepository($commitApi);
 
         $range = $commitRepository->items(
-            $owner,
-            $name,
+            $repository,
             $startReference,
             $endReference
         );

--- a/test/Unit/Repository/PullRequestRepositoryTest.php
+++ b/test/Unit/Repository/PullRequestRepositoryTest.php
@@ -33,8 +33,10 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
 
         $api = $this->createPullRequestApiMock();
 
@@ -44,8 +46,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('show')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->identicalTo($expectedItem->number)
             )
             ->willReturn($this->response($expectedItem));
@@ -56,8 +58,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         );
 
         $pullRequest = $pullRequestRepository->show(
-            $owner,
-            $name,
+            $repository,
             $expectedItem->number
         );
 
@@ -71,9 +72,12 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
         $number = $faker->numberBetween(1);
+
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
 
         $api = $this->createPullRequestApiMock();
 
@@ -81,8 +85,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('show')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->identicalTo($number)
             )
             ->willReturn('snafu');
@@ -94,15 +98,13 @@ final class PullRequestRepositoryTest extends Framework\TestCase
 
         $this->expectException(Exception\PullRequestNotFound::class);
         $this->expectExceptionMessage(\sprintf(
-            'Could not find pull request "%d" in "%s/%s".',
+            'Could not find pull request "%d" in "%s".',
             $number,
-            $owner,
-            $name
+            $repository
         ));
 
         $pullRequestRepository->show(
-            $owner,
-            $name,
+            $repository,
             $number
         );
     }
@@ -111,8 +113,11 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
+
         $startReference = $faker->sha1;
 
         $commitRepository = $this->createCommitRepositoryMock();
@@ -128,21 +133,19 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('items')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository),
                 $this->identicalTo($startReference),
                 $this->identicalTo(null)
             )
             ->willReturn($range);
 
-        $repository = new Repository\PullRequestRepository(
+        $pullRequestRepository = new Repository\PullRequestRepository(
             $this->createPullRequestApiMock(),
             $commitRepository
         );
 
-        $repository->items(
-            $owner,
-            $name,
+        $pullRequestRepository->items(
+            $repository,
             $startReference
         );
     }
@@ -151,8 +154,11 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
+
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
@@ -173,21 +179,19 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('items')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository),
                 $this->identicalTo($startReference),
                 $this->identicalTo($endReference)
             )
             ->willReturn($range);
 
-        $repository = new Repository\PullRequestRepository(
+        $pullRequestRepository = new Repository\PullRequestRepository(
             $this->createPullRequestApiMock(),
             $commitRepository
         );
 
-        $repository->items(
-            $owner,
-            $name,
+        $pullRequestRepository->items(
+            $repository,
             $startReference,
             $endReference
         );
@@ -197,8 +201,11 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
+
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
@@ -226,21 +233,19 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('items')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository),
                 $this->identicalTo($startReference),
                 $this->identicalTo($endReference)
             )
             ->willReturn($range);
 
-        $repository = new Repository\PullRequestRepository(
+        $pullRequestRepository = new Repository\PullRequestRepository(
             $this->createPullRequestApiMock(),
             $commitRepository
         );
 
-        $repository->items(
-            $owner,
-            $name,
+        $pullRequestRepository->items(
+            $repository,
             $startReference,
             $endReference
         );
@@ -250,8 +255,11 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
+
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
@@ -288,8 +296,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('items')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository),
                 $this->identicalTo($startReference),
                 $this->identicalTo($endReference)
             )
@@ -301,20 +308,19 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('show')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->identicalTo($expectedItem->number)
             )
             ->willReturn($this->response($expectedItem));
 
-        $repository = new Repository\PullRequestRepository(
+        $pullRequestRepository = new Repository\PullRequestRepository(
             $api,
             $commitRepository
         );
 
-        $actualRange = $repository->items(
-            $owner,
-            $name,
+        $actualRange = $pullRequestRepository->items(
+            $repository,
             $startReference,
             $endReference
         );
@@ -326,8 +332,11 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
+        $repository = new Resource\Repository(
+            $faker->slug(),
+            $faker->slug()
+        );
+
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
@@ -360,8 +369,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('items')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository),
                 $this->identicalTo($startReference),
                 $this->identicalTo($endReference)
             )
@@ -373,8 +381,8 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             ->expects($this->once())
             ->method('show')
             ->with(
-                $this->identicalTo($owner),
-                $this->identicalTo($name),
+                $this->identicalTo($repository->owner()),
+                $this->identicalTo($repository->name()),
                 $this->identicalTo($number)
             )
             ->willReturn(null);
@@ -385,8 +393,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         );
 
         $pullRequestRepository->items(
-            $owner,
-            $name,
+            $repository,
             $startReference,
             $endReference
         );


### PR DESCRIPTION
This PR

* [x] uses the previously created `Repository` resource instead of owner and name

Related to #136.