### PR TITLE
Enhancement: Combine owner and repository argument into repository argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ composer global require localheinz/github-changelog
 Create your changelogs anywhere:
 
 ```bash
-$ github-changelog generate localheinz github-changelog 0.1.1 0.1.2
+$ github-changelog generate localheinz/github-changelog 0.1.1 0.1.2
 ```
 
 Enjoy the changelog:
@@ -79,7 +79,7 @@ $ composer require --dev localheinz/github-changelog
 Create your changelog from within in your project:
 
 ```bash
-$ vendor/bin/github-changelog generate localheinz github-changelog ae63248 master
+$ vendor/bin/github-changelog generate localheinz/github-changelog ae63248 master
 ```
 
 Enjoy the changelog:

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -56,14 +56,9 @@ final class GenerateCommand extends Command
             ->setName('generate')
             ->setDescription('Generates a changelog from merged pull requests found between commit references')
             ->addArgument(
-                'owner',
-                Input\InputArgument::REQUIRED,
-                'The owner, e.g., "localheinz"'
-            )
-            ->addArgument(
                 'repository',
                 Input\InputArgument::REQUIRED,
-                'The repository, e.g. "github-changelog"'
+                'The repository, e.g. "localheinz/github-changelog"'
             )
             ->addArgument(
                 'start-reference',
@@ -111,14 +106,10 @@ final class GenerateCommand extends Command
         }
 
         try {
-            $repository = new Resource\Repository(
-                $input->getArgument('owner'),
-                $input->getArgument('repository')
-            );
+            $repository = Resource\Repository::fromString($input->getArgument('repository'));
         } catch (\InvalidArgumentException $exception) {
             $io->error(\sprintf(
-                'Owner "%s" and repository "%s" appear to be invalid.',
-                $input->getArgument('owner'),
+                'Repository "%s" appears to be invalid.',
                 $input->getArgument('repository')
             ));
 

--- a/test/Unit/Console/GenerateCommandTest.php
+++ b/test/Unit/Console/GenerateCommandTest.php
@@ -73,13 +73,9 @@ final class GenerateCommandTest extends Framework\TestCase
     public function providerArgument(): \Generator
     {
         $arguments = [
-            'owner' => [
-                true,
-                'The owner, e.g., "localheinz"',
-            ],
             'repository' => [
                 true,
-                'The repository, e.g. "github-changelog"',
+                'The repository, e.g. "localheinz/github-changelog"',
             ],
             'start-reference' => [
                 true,
@@ -185,21 +181,21 @@ final class GenerateCommandTest extends Framework\TestCase
         $tester = new CommandTester($command);
 
         $tester->execute([
-            'owner' => 'localheinz',
-            'repository' => 'github-changelog',
+            'repository' => 'localheinz/github-changelog',
             'start-reference' => '0.1.0',
             '--auth-token' => $authToken,
         ]);
     }
 
-    public function testExecuteFailsIfOwnerAndRepositoryAreInvalid()
+    public function testExecuteFailsIfRepositoryIsInvalid()
     {
-        $owner = '🤓';
-        $repository = '🤣';
+        $repository = $this->repositoryFrom(
+            '🤓',
+            '🤣'
+        );
 
         $expectedMessage = \sprintf(
-            'Owner "%s" and repository "%s" appear to be invalid.',
-            $owner,
+            'Repository "%s" appears to be invalid.',
             $repository
         );
 
@@ -211,7 +207,6 @@ final class GenerateCommandTest extends Framework\TestCase
         $tester = new CommandTester($command);
 
         $exitCode = $tester->execute([
-            'owner' => $owner,
             'repository' => $repository,
             'start-reference' => '0.1.0',
         ]);
@@ -226,8 +221,8 @@ final class GenerateCommandTest extends Framework\TestCase
 
         $owner = $faker->slug();
         $name = $faker->slug();
-        $startReference = $faker->unique()->sha1;
-        $endReference = $faker->unique()->sha1;
+        $startReference = $faker->sha1;
+        $endReference = $faker->sha1;
 
         $pullRequestRepository = $this->createPullRequestRepositoryMock();
 
@@ -255,8 +250,10 @@ final class GenerateCommandTest extends Framework\TestCase
         $tester = new CommandTester($command);
 
         $tester->execute([
-            'owner' => $owner,
-            'repository' => $name,
+            'repository' => $this->repositoryFrom(
+                $owner,
+                $name
+            ),
             'start-reference' => $startReference,
             'end-reference' => $endReference,
         ]);
@@ -265,11 +262,6 @@ final class GenerateCommandTest extends Framework\TestCase
     public function testExecuteRendersMessageIfNoPullRequestsWereFound()
     {
         $faker = $this->faker();
-
-        $owner = $faker->slug();
-        $name = $faker->slug();
-        $startReference = $faker->sha1;
-        $endReference = $faker->sha1;
 
         $expectedMessage = 'Could not find any pull requests';
 
@@ -288,10 +280,12 @@ final class GenerateCommandTest extends Framework\TestCase
         $tester = new CommandTester($command);
 
         $exitCode = $tester->execute([
-            'owner' => $owner,
-            'repository' => $name,
-            'start-reference' => $startReference,
-            'end-reference' => $endReference,
+            'repository' => $this->repositoryFrom(
+                $faker->slug(),
+                $faker->slug()
+            ),
+            'start-reference' => $faker->sha1,
+            'end-reference' => $faker->sha1,
         ]);
 
         $this->assertSame(0, $exitCode);
@@ -302,10 +296,6 @@ final class GenerateCommandTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
-        $startReference = $faker->sha1;
-
         $expectedMessage = 'Could not find any pull requests';
 
         $pullRequestRepository = $this->createPullRequestRepositoryMock();
@@ -323,9 +313,11 @@ final class GenerateCommandTest extends Framework\TestCase
         $tester = new CommandTester($command);
 
         $exitCode = $tester->execute([
-            'owner' => $owner,
-            'repository' => $name,
-            'start-reference' => $startReference,
+            'repository' => $this->repositoryFrom(
+                $faker->slug(),
+                $faker->slug()
+            ),
+            'start-reference' => $faker->sha1,
             'end-reference' => null,
         ]);
 
@@ -337,10 +329,6 @@ final class GenerateCommandTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
-        $startReference = $faker->sha1;
-        $endReference = $faker->sha1;
         $count = $faker->numberBetween(1, 5);
 
         $pullRequests = $this->pullRequests($count);
@@ -384,10 +372,12 @@ final class GenerateCommandTest extends Framework\TestCase
         $tester = new CommandTester($command);
 
         $exitCode = $tester->execute([
-            'owner' => $owner,
-            'repository' => $name,
-            'start-reference' => $startReference,
-            'end-reference' => $endReference,
+            'repository' => $this->repositoryFrom(
+                $faker->slug(),
+                $faker->slug()
+            ),
+            'start-reference' => $faker->sha1,
+            'end-reference' => $faker->sha1,
             '--template' => $template,
         ]);
 
@@ -402,9 +392,6 @@ final class GenerateCommandTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $owner = $faker->slug();
-        $name = $faker->slug();
-        $startReference = $faker->sha1;
         $count = $faker->numberBetween(1, 5);
 
         $pullRequests = $this->pullRequests($count);
@@ -430,9 +417,11 @@ final class GenerateCommandTest extends Framework\TestCase
         $tester = new CommandTester($command);
 
         $exitCode = $tester->execute([
-            'owner' => $owner,
-            'repository' => $name,
-            'start-reference' => $startReference,
+            'repository' => $this->repositoryFrom(
+                $faker->slug(),
+                $faker->slug()
+            ),
+            'start-reference' => $faker->sha1,
             'end-reference' => null,
         ]);
 
@@ -466,10 +455,12 @@ final class GenerateCommandTest extends Framework\TestCase
         $tester = new CommandTester($command);
 
         $exitCode = $tester->execute([
-            'owner' => $faker->unique()->slug(),
-            'repository' => $faker->unique()->slug(),
-            'start-reference' => $faker->unique()->sha1,
-            'end-reference' => $faker->unique()->sha1,
+            'repository' => $this->repositoryFrom(
+                $faker->slug(),
+                $faker->slug()
+            ),
+            'start-reference' => $faker->sha1,
+            'end-reference' => $faker->sha1,
         ]);
 
         $this->assertSame(1, $exitCode);
@@ -536,5 +527,14 @@ final class GenerateCommandTest extends Framework\TestCase
         }
 
         return $pullRequests;
+    }
+
+    private function repositoryFrom(string $owner, string $name): string
+    {
+        return \sprintf(
+            '%s/%s',
+            $owner,
+            $name
+        );
     }
 }


### PR DESCRIPTION
This PR

* [x] combines the `owner` and `repository` arguments to the `GenerateCommand` into a single `repository` argument

Related to #136.