### PR TITLE
Enhancement: Allow to create resource from owner and name

### DIFF
--- a/src/Resource/Repository.php
+++ b/src/Resource/Repository.php
@@ -27,17 +27,8 @@ final class Repository implements RepositoryInterface
      */
     private $name;
 
-    /**
-     * @param string $owner
-     * @param string $name
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function __construct(string $owner, string $name)
+    private function __construct(string $owner, string $name)
     {
-        Assert\that($owner)->regex(self::ownerRegEx());
-        Assert\that($name)->regex(self::nameRegEx());
-
         $this->owner = $owner;
         $this->name = $name;
     }
@@ -52,11 +43,30 @@ final class Repository implements RepositoryInterface
     }
 
     /**
+     * @param string $owner
+     * @param string $name
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return self
+     */
+    public static function fromOwnerAndName(string $owner, string $name): self
+    {
+        Assert\that($owner)->regex(self::ownerRegEx());
+        Assert\that($name)->regex(self::nameRegEx());
+
+        return new self(
+            $owner,
+            $name
+        );
+    }
+
+    /**
      * @param string $string
      *
      * @throws \InvalidArgumentException
      *
-     * @return Repository
+     * @return self
      */
     public static function fromString(string $string): self
     {

--- a/test/Unit/Exception/PullRequestNotFoundTest.php
+++ b/test/Unit/Exception/PullRequestNotFoundTest.php
@@ -39,7 +39,7 @@ final class PullRequestNotFoundTest extends Framework\TestCase
 
         $number = $faker->numberBetween(1);
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );

--- a/test/Unit/Exception/ReferenceNotFoundTest.php
+++ b/test/Unit/Exception/ReferenceNotFoundTest.php
@@ -37,7 +37,7 @@ final class ReferenceNotFoundTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );

--- a/test/Unit/Repository/CommitRepositoryTest.php
+++ b/test/Unit/Repository/CommitRepositoryTest.php
@@ -33,7 +33,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );
@@ -71,7 +71,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );
@@ -104,7 +104,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );
@@ -137,7 +137,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );
@@ -169,7 +169,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );
@@ -203,7 +203,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );
@@ -251,7 +251,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );
@@ -283,7 +283,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );
@@ -324,7 +324,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );
@@ -375,7 +375,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );
@@ -431,7 +431,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );
@@ -473,7 +473,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );
@@ -571,7 +571,7 @@ final class CommitRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );

--- a/test/Unit/Repository/PullRequestRepositoryTest.php
+++ b/test/Unit/Repository/PullRequestRepositoryTest.php
@@ -33,7 +33,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );
@@ -74,7 +74,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
 
         $number = $faker->numberBetween(1);
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );
@@ -113,7 +113,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );
@@ -154,7 +154,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );
@@ -201,7 +201,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );
@@ -255,7 +255,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );
@@ -332,7 +332,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
     {
         $faker = $this->faker();
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $faker->slug(),
             $faker->slug()
         );

--- a/test/Unit/Resource/RepositoryTest.php
+++ b/test/Unit/Resource/RepositoryTest.php
@@ -31,7 +31,7 @@ final class RepositoryTest extends Framework\TestCase
      *
      * @param string $owner
      */
-    public function testConstructorRejectsInvalidOwner(string $owner)
+    public function testFromOwnerAndNameRejectsInvalidOwner(string $owner)
     {
         $faker = $this->faker();
 
@@ -39,7 +39,7 @@ final class RepositoryTest extends Framework\TestCase
 
         $this->expectException(\InvalidArgumentException::class);
 
-        new Resource\Repository(
+        Resource\Repository::fromOwnerAndName(
             $owner,
             $name
         );
@@ -59,7 +59,7 @@ final class RepositoryTest extends Framework\TestCase
      *
      * @param string $name
      */
-    public function testConstructorRejectsInvalidName(string $name)
+    public function testFromOwnerAndNameRejectsInvalidName(string $name)
     {
         $faker = $this->faker();
 
@@ -67,7 +67,7 @@ final class RepositoryTest extends Framework\TestCase
 
         $this->expectException(\InvalidArgumentException::class);
 
-        new Resource\Repository(
+        Resource\Repository::fromOwnerAndName(
             $owner,
             $name
         );
@@ -88,13 +88,14 @@ final class RepositoryTest extends Framework\TestCase
      * @param string $owner
      * @param string $name
      */
-    public function testConstructorSetsValues(string $owner, string $name)
+    public function testFromOwnerAndNameReturnsRepository(string $owner, string $name)
     {
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $owner,
             $name
         );
 
+        $this->assertInstanceOf(Resource\RepositoryInterface::class, $repository);
         $this->assertSame($owner, $repository->owner());
         $this->assertSame($name, $repository->name());
     }
@@ -106,7 +107,7 @@ final class RepositoryTest extends Framework\TestCase
         $owner = $faker->slug();
         $name = $faker->slug();
 
-        $repository = new Resource\Repository(
+        $repository = Resource\Repository::fromOwnerAndName(
             $owner,
             $name
         );


### PR DESCRIPTION
This PR

* [x] adds `fromOwnerAndName()` as a named constructor to `Resource` and reduces the visibility of `__construct()` to `private`