### PR TITLE
Fix: Require value for options

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -73,13 +73,13 @@ final class GenerateCommand extends Command
             ->addOption(
                 'auth-token',
                 'a',
-                Input\InputOption::VALUE_OPTIONAL,
+                Input\InputOption::VALUE_REQUIRED,
                 'The GitHub token'
             )
             ->addOption(
                 'template',
                 't',
-                Input\InputOption::VALUE_OPTIONAL,
+                Input\InputOption::VALUE_REQUIRED,
                 'The template to use for rendering a pull request',
                 '- %title% (#%number%)'
             );

--- a/test/Unit/Console/GenerateCommandTest.php
+++ b/test/Unit/Console/GenerateCommandTest.php
@@ -129,13 +129,13 @@ final class GenerateCommandTest extends Framework\TestCase
         $options = [
             'auth-token' => [
                 'a',
-                false,
+                true,
                 'The GitHub token',
                 null,
             ],
             'template' => [
                 't',
-                false,
+                true,
                 'The template to use for rendering a pull request',
                 '- %title% (#%number%)',
             ],


### PR DESCRIPTION
This PR

* [x] requires a value for options where values are actually required