### PR TITLE
Fix: Remove shebang from github-changelog.php

### DIFF
--- a/github-changelog.php
+++ b/github-changelog.php
@@ -1,5 +1,15 @@
-#!/usr/bin/env php
 <?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/github-changelog
+ */
 
 use Github\Api;
 use Github\Client;


### PR DESCRIPTION
This PR

* [x] removes a shebang from `github-changelog.php` and turns off the executable flag