### PR TITLE
Fix: Wording

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -152,7 +152,7 @@ final class GenerateCommand extends Command
         );
 
         $io->section(\sprintf(
-            'Pull Requests for %s %s',
+            'Pull Requests merged in %s %s',
             $repository,
             $range
         ));


### PR DESCRIPTION
This PR

* [x]  fixes the wording for output generated by the `GenerateCommand`