### PR TITLE
Fix: Dots in repository names should be acceptable

### DIFF
--- a/src/Resource/Repository.php
+++ b/src/Resource/Repository.php
@@ -134,7 +134,7 @@ final class Repository implements RepositoryInterface
 
     private static function nameRegEx(bool $asPartial = false): string
     {
-        $regEx = '(?P<name>[a-zA-Z0-9-_]+)';
+        $regEx = '(?P<name>[a-zA-Z0-9-_.]+)';
 
         if (true === $asPartial) {
             return $regEx;

--- a/test/Util/DataProvider.php
+++ b/test/Util/DataProvider.php
@@ -356,6 +356,10 @@ final class DataProvider
                 $faker->word,
                 $faker->numberBetween(1)
             ),
+            'words-separated-by-dots' => \implode(
+                '.',
+                $faker->words()
+            ),
             'words-separated-by-hyphen' => \implode(
                 '-',
                 $faker->words()
@@ -363,6 +367,13 @@ final class DataProvider
             'words-separated-by-underscore' => \implode(
                 '-',
                 $faker->words()
+            ),
+            'words-with-numbers-separated-by-dots' => \implode(
+                '.',
+                \array_merge($faker->words(), [
+                    $faker->numberBetween(1),
+                    $faker->numberBetween(1),
+                ])
             ),
             'words-with-numbers-separated-by-hyphens' => \implode(
                 '-',


### PR DESCRIPTION
This PR

* [x] asserts that repository names containing `.` are accepted
* [x] adjusts a regular expression to accept repository names containing `.`