### PR TITLE
Enhancement: Update localheinz/php-cs-fixer-config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ jobs:
         - if [[ -n "$GITHUB_TOKEN" ]]; then composer config github-oauth.github.com $GITHUB_TOKEN; fi
 
       install:
-        - if [[ "$TRAVIS_PHP_VERSION" == "7.3" ]]; then composer remove --dev localheinz/php-cs-fixer-config; fi
         - composer install
 
       script:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "infection/infection": "~0.7.0",
         "localheinz/composer-normalize": "^1.0.0",
-        "localheinz/php-cs-fixer-config": "~1.17.0",
+        "localheinz/php-cs-fixer-config": "~1.19.0",
         "localheinz/test-util": "~0.7.0",
         "phpunit/phpunit": "^6.5.5"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6744861d72f6fc291ff38580ad2b12ca",
+    "content-hash": "4d5019d89ece454c1d3a22bc657767ed",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -1094,7 +1094,7 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v3.4.19",
+            "version": "v3.4.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
@@ -1737,16 +1737,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.13.1",
+            "version": "v2.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "54814c62d5beef3ba55297b9b3186ed8b8a1b161"
+                "reference": "b788ea0af899cedc8114dca7db119c93b6685da2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/54814c62d5beef3ba55297b9b3186ed8b8a1b161",
-                "reference": "54814c62d5beef3ba55297b9b3186ed8b8a1b161",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/b788ea0af899cedc8114dca7db119c93b6685da2",
+                "reference": "b788ea0af899cedc8114dca7db119c93b6685da2",
                 "shasum": ""
             },
             "require": {
@@ -1755,7 +1755,7 @@
                 "doctrine/annotations": "^1.2",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": "^5.6 || >=7.0 <7.3",
+                "php": "^5.6 || ^7.0",
                 "php-cs-fixer/diff": "^1.3",
                 "symfony/console": "^3.4.17 || ^4.1.6",
                 "symfony/event-dispatcher": "^3.0 || ^4.0",
@@ -1773,7 +1773,7 @@
             "require-dev": {
                 "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
                 "justinrainbow/json-schema": "^5.0",
-                "keradus/cli-executor": "^1.1",
+                "keradus/cli-executor": "^1.2",
                 "mikey179/vfsstream": "^1.6",
                 "php-coveralls/php-coveralls": "^2.1",
                 "php-cs-fixer/accessible-object": "^1.0",
@@ -1793,6 +1793,11 @@
                 "php-cs-fixer"
             ],
             "type": "application",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.14-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "PhpCsFixer\\": "src/"
@@ -1824,7 +1829,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2018-10-21T00:32:10+00:00"
+            "time": "2019-01-04T18:29:47+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -2262,20 +2267,20 @@
         },
         {
             "name": "localheinz/php-cs-fixer-config",
-            "version": "1.17.0",
+            "version": "1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localheinz/php-cs-fixer-config.git",
-                "reference": "d4835786b5e949ebaf76d29fc8b5b6237ee1e115"
+                "reference": "6237bcf8636243bc2d1a995f67c49ac58cb76188"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localheinz/php-cs-fixer-config/zipball/d4835786b5e949ebaf76d29fc8b5b6237ee1e115",
-                "reference": "d4835786b5e949ebaf76d29fc8b5b6237ee1e115",
+                "url": "https://api.github.com/repos/localheinz/php-cs-fixer-config/zipball/6237bcf8636243bc2d1a995f67c49ac58cb76188",
+                "reference": "6237bcf8636243bc2d1a995f67c49ac58cb76188",
                 "shasum": ""
             },
             "require": {
-                "friendsofphp/php-cs-fixer": "^2.13.1",
+                "friendsofphp/php-cs-fixer": "^2.14.0",
                 "php": "^5.6 || ^7.0"
             },
             "require-dev": {
@@ -2299,7 +2304,7 @@
             ],
             "description": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
             "homepage": "https://github.com/localheinz/php-cs-fixer-config",
-            "time": "2018-11-27T07:03:30+00:00"
+            "time": "2019-01-04T23:09:58+00:00"
         },
         {
             "name": "localheinz/test-util",
@@ -4116,21 +4121,90 @@
             "time": "2015-10-13T18:44:15+00:00"
         },
         {
-            "name": "symfony/event-dispatcher",
-            "version": "v4.1.8",
+            "name": "symfony/contracts",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "8b93ce06506d58485893e2da366767dcc5390862"
+                "url": "https://github.com/symfony/contracts.git",
+                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/8b93ce06506d58485893e2da366767dcc5390862",
-                "reference": "8b93ce06506d58485893e2da366767dcc5390862",
+                "url": "https://api.github.com/repos/symfony/contracts/zipball/1aa7ab2429c3d594dd70689604b5cf7421254cdf",
+                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "psr/cache": "When using the Cache contracts",
+                "psr/container": "When using the Service contracts",
+                "symfony/cache-contracts-implementation": "",
+                "symfony/service-contracts-implementation": "",
+                "symfony/translation-contracts-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\": ""
+                },
+                "exclude-from-classmap": [
+                    "**/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A set of abstractions extracted out of the Symfony components",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2018-12-05T08:06:11+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v4.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "921f49c3158a276d27c0d770a5a347a3b718b328"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/921f49c3158a276d27c0d770a5a347a3b718b328",
+                "reference": "921f49c3158a276d27c0d770a5a347a3b718b328",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/contracts": "^1.0"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4"
@@ -4149,7 +4223,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -4176,20 +4250,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-26T10:26:29+00:00"
+            "time": "2018-12-01T08:52:38+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.1.8",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "71cc7693940bdad4dac4b038acd46b4f1ae7d2ca"
+                "reference": "2f4c8b999b3b7cadb2a69390b01af70886753710"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/71cc7693940bdad4dac4b038acd46b4f1ae7d2ca",
-                "reference": "71cc7693940bdad4dac4b038acd46b4f1ae7d2ca",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/2f4c8b999b3b7cadb2a69390b01af70886753710",
+                "reference": "2f4c8b999b3b7cadb2a69390b01af70886753710",
                 "shasum": ""
             },
             "require": {
@@ -4199,7 +4273,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -4226,20 +4300,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-11T19:51:29+00:00"
+            "time": "2018-11-11T19:52:12+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v4.1.8",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "68fbdcafe915db67adb13fddaec4532e684f6689"
+                "reference": "e53d477d7b5c4982d0e1bfd2298dbee63d01441d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/68fbdcafe915db67adb13fddaec4532e684f6689",
-                "reference": "68fbdcafe915db67adb13fddaec4532e684f6689",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e53d477d7b5c4982d0e1bfd2298dbee63d01441d",
+                "reference": "e53d477d7b5c4982d0e1bfd2298dbee63d01441d",
                 "shasum": ""
             },
             "require": {
@@ -4248,7 +4322,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -4275,7 +4349,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-11T19:51:29+00:00"
+            "time": "2018-11-11T19:52:12+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4451,16 +4525,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v4.1.8",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "471f6e24172366a97365baaae588ddaafbba9b20"
+                "reference": "2b341009ccec76837a7f46f59641b431e4d4c2b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/471f6e24172366a97365baaae588ddaafbba9b20",
-                "reference": "471f6e24172366a97365baaae588ddaafbba9b20",
+                "url": "https://api.github.com/repos/symfony/process/zipball/2b341009ccec76837a7f46f59641b431e4d4c2b0",
+                "reference": "2b341009ccec76837a7f46f59641b431e4d4c2b0",
                 "shasum": ""
             },
             "require": {
@@ -4469,7 +4543,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -4496,7 +4570,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-20T16:14:00+00:00"
+            "time": "2018-11-20T16:22:05+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/github-changelog.php
+++ b/github-changelog.php
@@ -3,13 +3,14 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
  * @see https://github.com/localheinz/github-changelog
  */
+
 use Github\Api;
 use Github\Client;
 use Localheinz\GitHub\ChangeLog;

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -61,7 +61,7 @@ final class GenerateCommand extends Command
         $this->stopwatch = new Stopwatch();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('generate')
@@ -181,7 +181,7 @@ final class GenerateCommand extends Command
 
             $pullRequests = \array_reverse($pullRequests);
 
-            \array_walk($pullRequests, static function (Resource\PullRequestInterface $pullRequest) use ($output, $template) {
+            \array_walk($pullRequests, static function (Resource\PullRequestInterface $pullRequest) use ($output, $template): void {
                 $message = \str_replace(
                     [
                         '%pullrequest.title%',

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Exception/PullRequestNotFound.php
+++ b/src/Exception/PullRequestNotFound.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Exception/ReferenceNotFound.php
+++ b/src/Exception/ReferenceNotFound.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Repository/CommitRepository.php
+++ b/src/Repository/CommitRepository.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -133,7 +133,7 @@ final class CommitRepository implements CommitRepositoryInterface
             return $range;
         }
 
-        \array_walk($response, static function ($data) use (&$range) {
+        \array_walk($response, static function ($data) use (&$range): void {
             $commit = new Resource\Commit(
                 $data['sha'],
                 $data['commit']['message']

--- a/src/Repository/CommitRepositoryInterface.php
+++ b/src/Repository/CommitRepositoryInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Repository/PullRequestRepository.php
+++ b/src/Repository/PullRequestRepository.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -67,7 +67,7 @@ final class PullRequestRepository implements PullRequestRepositoryInterface
 
         $commits = $range->commits();
 
-        \array_walk($commits, function (Resource\CommitInterface $commit) use (&$range, $repository) {
+        \array_walk($commits, function (Resource\CommitInterface $commit) use (&$range, $repository): void {
             if (0 === \preg_match('/^Merge pull request #(?P<number>\d+)/', $commit->message(), $matches)) {
                 return;
             }

--- a/src/Repository/PullRequestRepositoryInterface.php
+++ b/src/Repository/PullRequestRepositoryInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Resource/Commit.php
+++ b/src/Resource/Commit.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Resource/CommitInterface.php
+++ b/src/Resource/CommitInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Resource/PullRequest.php
+++ b/src/Resource/PullRequest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Resource/PullRequestInterface.php
+++ b/src/Resource/PullRequestInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Resource/Range.php
+++ b/src/Resource/Range.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Resource/RangeInterface.php
+++ b/src/Resource/RangeInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Resource/Repository.php
+++ b/src/Resource/Repository.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Resource/RepositoryInterface.php
+++ b/src/Resource/RepositoryInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Resource/User.php
+++ b/src/Resource/User.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Resource/UserInterface.php
+++ b/src/Resource/UserInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Util/Git.php
+++ b/src/Util/Git.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Util/GitInterface.php
+++ b/src/Util/GitInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Util/RepositoryResolver.php
+++ b/src/Util/RepositoryResolver.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Util/RepositoryResolverInterface.php
+++ b/src/Util/RepositoryResolverInterface.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Unit/Console/GenerateCommandTest.php
+++ b/test/Unit/Console/GenerateCommandTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -31,7 +31,7 @@ final class GenerateCommandTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testHasName()
+    public function testHasName(): void
     {
         $command = new Console\GenerateCommand(
             $this->createClientMock(),
@@ -42,7 +42,7 @@ final class GenerateCommandTest extends Framework\TestCase
         self::assertSame('generate', $command->getName());
     }
 
-    public function testHasDescription()
+    public function testHasDescription(): void
     {
         $command = new Console\GenerateCommand(
             $this->createClientMock(),
@@ -60,7 +60,7 @@ final class GenerateCommandTest extends Framework\TestCase
      * @param bool   $isRequired
      * @param string $description
      */
-    public function testArgument(string $name, bool $isRequired, string $description)
+    public function testArgument(string $name, bool $isRequired, string $description): void
     {
         $command = new Console\GenerateCommand(
             $this->createClientMock(),
@@ -109,7 +109,7 @@ final class GenerateCommandTest extends Framework\TestCase
      * @param string $description
      * @param mixed  $default
      */
-    public function testOption(string $name, string $shortcut, bool $isValueRequired, string $description, $default)
+    public function testOption(string $name, string $shortcut, bool $isValueRequired, string $description, $default): void
     {
         $command = new Console\GenerateCommand(
             $this->createClientMock(),
@@ -129,7 +129,7 @@ final class GenerateCommandTest extends Framework\TestCase
         self::assertSame($default, $option->getDefault());
     }
 
-    public function testExecuteAuthenticatesIfTokenOptionIsGiven()
+    public function testExecuteAuthenticatesIfTokenOptionIsGiven(): void
     {
         $authToken = $this->faker()->password();
 
@@ -165,7 +165,7 @@ final class GenerateCommandTest extends Framework\TestCase
         ]);
     }
 
-    public function testExecuteFailsIfRepositoryIsInvalid()
+    public function testExecuteFailsIfRepositoryIsInvalid(): void
     {
         $repository = $this->repositoryFrom(
             '🤓',
@@ -194,7 +194,7 @@ final class GenerateCommandTest extends Framework\TestCase
         self::assertContains($expectedMessage, $tester->getDisplay());
     }
 
-    public function testExecuteFailsIfRepositoryCannotBeResolved()
+    public function testExecuteFailsIfRepositoryCannotBeResolved(): void
     {
         $repositoryResolver = $this->createRepositoryResolverMock();
 
@@ -225,7 +225,7 @@ final class GenerateCommandTest extends Framework\TestCase
         self::assertContains($expectedMessage, $tester->getDisplay());
     }
 
-    public function testExecuteDelegatesToPullRequestRepositoryUsingRepositoryResolvedFromGitMetaData()
+    public function testExecuteDelegatesToPullRequestRepositoryUsingRepositoryResolvedFromGitMetaData(): void
     {
         $faker = $this->faker();
 
@@ -277,7 +277,7 @@ final class GenerateCommandTest extends Framework\TestCase
         ]);
     }
 
-    public function testExecuteDelegatesToPullRequestRepositoryUsingRepositorySpecifiedInOptions()
+    public function testExecuteDelegatesToPullRequestRepositoryUsingRepositorySpecifiedInOptions(): void
     {
         $faker = $this->faker();
 
@@ -328,7 +328,7 @@ final class GenerateCommandTest extends Framework\TestCase
         ]);
     }
 
-    public function testExecuteRendersMessageIfNoPullRequestsWereFound()
+    public function testExecuteRendersMessageIfNoPullRequestsWereFound(): void
     {
         $faker = $this->faker();
 
@@ -362,7 +362,7 @@ final class GenerateCommandTest extends Framework\TestCase
         self::assertRegExp('@' . $expectedMessage . '@', $tester->getDisplay());
     }
 
-    public function testExecuteRendersDifferentMessageIfNoPullRequestsWereFoundAndNoEndReferenceWasGiven()
+    public function testExecuteRendersDifferentMessageIfNoPullRequestsWereFoundAndNoEndReferenceWasGiven(): void
     {
         $faker = $this->faker();
 
@@ -396,7 +396,7 @@ final class GenerateCommandTest extends Framework\TestCase
         self::assertContains($expectedMessage, $tester->getDisplay());
     }
 
-    public function testExecuteRendersPullRequestsWithTemplate()
+    public function testExecuteRendersPullRequestsWithTemplate(): void
     {
         $faker = $this->faker();
 
@@ -414,7 +414,7 @@ final class GenerateCommandTest extends Framework\TestCase
             ),
         ];
 
-        \array_walk($pullRequests, static function (Resource\PullRequestInterface $pullRequest) use (&$expectedMessages, $template) {
+        \array_walk($pullRequests, static function (Resource\PullRequestInterface $pullRequest) use (&$expectedMessages, $template): void {
             $expectedMessages[] = \str_replace(
                 [
                     '%pullrequest.title%',
@@ -464,7 +464,7 @@ final class GenerateCommandTest extends Framework\TestCase
         }
     }
 
-    public function testExecuteRendersDifferentMessageWhenNoEndReferenceWasGiven()
+    public function testExecuteRendersDifferentMessageWhenNoEndReferenceWasGiven(): void
     {
         $faker = $this->faker();
 
@@ -506,7 +506,7 @@ final class GenerateCommandTest extends Framework\TestCase
         self::assertContains($expectedMessage, $tester->getDisplay());
     }
 
-    public function testExecuteHandlesExceptionsThrownWhenFetchingPullRequests()
+    public function testExecuteHandlesExceptionsThrownWhenFetchingPullRequests(): void
     {
         $faker = $this->faker();
 

--- a/test/Unit/Exception/InvalidArgumentExceptionTest.php
+++ b/test/Unit/Exception/InvalidArgumentExceptionTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -25,12 +25,12 @@ final class InvalidArgumentExceptionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testExtendsInvalidArgumentException()
+    public function testExtendsInvalidArgumentException(): void
     {
         $this->assertClassExtends(\InvalidArgumentException::class, InvalidArgumentException::class);
     }
 
-    public function testImplementsExceptionInterface()
+    public function testImplementsExceptionInterface(): void
     {
         $this->assertClassImplementsInterface(ExceptionInterface::class, InvalidArgumentException::class);
     }

--- a/test/Unit/Exception/PullRequestNotFoundTest.php
+++ b/test/Unit/Exception/PullRequestNotFoundTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -26,17 +26,17 @@ final class PullRequestNotFoundTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testExtendsRuntimeException()
+    public function testExtendsRuntimeException(): void
     {
         $this->assertClassExtends(\RuntimeException::class, PullRequestNotFound::class);
     }
 
-    public function testImplementsExceptionInterface()
+    public function testImplementsExceptionInterface(): void
     {
         $this->assertClassImplementsInterface(ExceptionInterface::class, PullRequestNotFound::class);
     }
 
-    public function testFromRepositoryAndNumberCreatesException()
+    public function testFromRepositoryAndNumberCreatesException(): void
     {
         $faker = $this->faker();
 

--- a/test/Unit/Exception/ReferenceNotFoundTest.php
+++ b/test/Unit/Exception/ReferenceNotFoundTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -26,17 +26,17 @@ final class ReferenceNotFoundTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testExtendsRuntimeException()
+    public function testExtendsRuntimeException(): void
     {
         $this->assertClassExtends(\RuntimeException::class, ReferenceNotFound::class);
     }
 
-    public function testImplementsExceptionInterface()
+    public function testImplementsExceptionInterface(): void
     {
         $this->assertClassImplementsInterface(ExceptionInterface::class, ReferenceNotFound::class);
     }
 
-    public function testFromRepositoryAndReferenceCreatesException()
+    public function testFromRepositoryAndReferenceCreatesException(): void
     {
         $faker = $this->faker();
 

--- a/test/Unit/Exception/RuntimeExceptionTest.php
+++ b/test/Unit/Exception/RuntimeExceptionTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -25,12 +25,12 @@ final class RuntimeExceptionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testExtendsRuntimeException()
+    public function testExtendsRuntimeException(): void
     {
         $this->assertClassExtends(\RuntimeException::class, RuntimeException::class);
     }
 
-    public function testImplementsExceptionInterface()
+    public function testImplementsExceptionInterface(): void
     {
         $this->assertClassImplementsInterface(ExceptionInterface::class, RuntimeException::class);
     }

--- a/test/Unit/ProjectCodeTest.php
+++ b/test/Unit/ProjectCodeTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -23,12 +23,12 @@ final class ProjectCodeTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testProductionClassesAreAbstractOrFinal()
+    public function testProductionClassesAreAbstractOrFinal(): void
     {
         $this->assertClassesAreAbstractOrFinal(__DIR__ . '/../../src');
     }
 
-    public function testProductionClassesHaveTests()
+    public function testProductionClassesHaveTests(): void
     {
         $this->assertClassesHaveTests(
             __DIR__ . '/../../src',
@@ -37,7 +37,7 @@ final class ProjectCodeTest extends Framework\TestCase
         );
     }
 
-    public function testTestClassesAreAbstractOrFinal()
+    public function testTestClassesAreAbstractOrFinal(): void
     {
         $this->assertClassesAreAbstractOrFinal(__DIR__ . '/..');
     }

--- a/test/Unit/Repository/CommitRepositoryTest.php
+++ b/test/Unit/Repository/CommitRepositoryTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -27,12 +27,12 @@ final class CommitRepositoryTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testImplementsCommitRepositoryInterface()
+    public function testImplementsCommitRepositoryInterface(): void
     {
         $this->assertClassImplementsInterface(Repository\CommitRepositoryInterface::class, Repository\CommitRepository::class);
     }
 
-    public function testShowReturnsCommitEntityWithShaAndMessageOnSuccess()
+    public function testShowReturnsCommitEntityWithShaAndMessageOnSuccess(): void
     {
         $faker = $this->faker();
 
@@ -70,7 +70,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         self::assertSame($expectedItem['commit']['message'], $commit->message());
     }
 
-    public function testShowThrowsCommitNotFoundOnFailure()
+    public function testShowThrowsCommitNotFoundOnFailure(): void
     {
         $faker = $this->faker();
 
@@ -103,7 +103,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         );
     }
 
-    public function testAllReturnsEmptyArrayOnFailure()
+    public function testAllReturnsEmptyArrayOnFailure(): void
     {
         $faker = $this->faker();
 
@@ -136,7 +136,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         self::assertCount(0, $range->commits());
     }
 
-    public function testAllSetsParamsPerPageTo250()
+    public function testAllSetsParamsPerPageTo250(): void
     {
         $faker = $this->faker();
 
@@ -168,7 +168,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         ]);
     }
 
-    public function testAllStillAllowsSettingPerPage()
+    public function testAllStillAllowsSettingPerPage(): void
     {
         $faker = $this->faker();
 
@@ -202,7 +202,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         ]);
     }
 
-    public function testAllReturnsRange()
+    public function testAllReturnsRange(): void
     {
         $faker = $this->faker();
 
@@ -239,7 +239,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         self::assertCount(\count($expectedItems), $commits);
 
-        \array_walk($commits, static function (Resource\CommitInterface $commit) use (&$expectedItems) {
+        \array_walk($commits, static function (Resource\CommitInterface $commit) use (&$expectedItems): void {
             /*
              * API returns commits in reverse order
              */
@@ -250,7 +250,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         });
     }
 
-    public function testItemsDoesNotFetchCommitsIfStartAndEndReferencesAreTheSame()
+    public function testItemsDoesNotFetchCommitsIfStartAndEndReferencesAreTheSame(): void
     {
         $faker = $this->faker();
 
@@ -282,7 +282,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         self::assertEmpty($range->pullRequests());
     }
 
-    public function testItemsDoesNotFetchCommitsIfStartCommitCouldNotBeFound()
+    public function testItemsDoesNotFetchCommitsIfStartCommitCouldNotBeFound(): void
     {
         $faker = $this->faker();
 
@@ -323,7 +323,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         self::assertEmpty($range->pullRequests());
     }
 
-    public function testItemsDoesNotFetchCommitsIfEndCommitCouldNotBeFound()
+    public function testItemsDoesNotFetchCommitsIfEndCommitCouldNotBeFound(): void
     {
         $faker = $this->faker();
 
@@ -374,7 +374,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         self::assertEmpty($range->pullRequests());
     }
 
-    public function testItemsFetchesCommitsUsingShaFromEndCommit()
+    public function testItemsFetchesCommitsUsingShaFromEndCommit(): void
     {
         $faker = $this->faker();
 
@@ -430,7 +430,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         );
     }
 
-    public function testItemsFetchesCommitsIfEndReferenceIsNotGiven()
+    public function testItemsFetchesCommitsIfEndReferenceIsNotGiven(): void
     {
         $faker = $this->faker();
 
@@ -472,7 +472,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         );
     }
 
-    public function testItemsReturnsRangeOfCommitsFromEndToStartExcludingStart()
+    public function testItemsReturnsRangeOfCommitsFromEndToStartExcludingStart(): void
     {
         $faker = $this->faker();
 
@@ -554,7 +554,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         self::assertCount(\count($expectedItems), $commits);
 
-        \array_walk($commits, static function ($commit) use (&$expectedItems) {
+        \array_walk($commits, static function ($commit) use (&$expectedItems): void {
             /*
              * API returns items in reverse order
              */
@@ -568,7 +568,7 @@ final class CommitRepositoryTest extends Framework\TestCase
         });
     }
 
-    public function testItemsFetchesMoreCommitsIfEndIsNotContainedInFirstBatch()
+    public function testItemsFetchesMoreCommitsIfEndIsNotContainedInFirstBatch(): void
     {
         $faker = $this->faker();
 
@@ -674,7 +674,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         self::assertCount(\count($expectedItems), $commits);
 
-        \array_walk($commits, static function ($commit) use (&$expectedItems) {
+        \array_walk($commits, static function ($commit) use (&$expectedItems): void {
             /*
              * API returns items in reverse order
              */

--- a/test/Unit/Repository/PullRequestRepositoryTest.php
+++ b/test/Unit/Repository/PullRequestRepositoryTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -27,12 +27,12 @@ final class PullRequestRepositoryTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testImplementsPullRequestRepositoryInterface()
+    public function testImplementsPullRequestRepositoryInterface(): void
     {
         $this->assertClassImplementsInterface(Repository\PullRequestRepositoryInterface::class, Repository\PullRequestRepository::class);
     }
 
-    public function testShowReturnsPullRequestEntityWithNumberTitleAndAuthorOnSuccess()
+    public function testShowReturnsPullRequestEntityWithNumberTitleAndAuthorOnSuccess(): void
     {
         $faker = $this->faker();
 
@@ -72,7 +72,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         self::assertSame($expectedItem['user']['login'], $pullRequest->author()->login());
     }
 
-    public function testShowThrowsPullRequestNotFoundOnFailure()
+    public function testShowThrowsPullRequestNotFoundOnFailure(): void
     {
         $faker = $this->faker();
 
@@ -113,7 +113,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         );
     }
 
-    public function testItemsDoesNotRequireAnEndReference()
+    public function testItemsDoesNotRequireAnEndReference(): void
     {
         $faker = $this->faker();
 
@@ -154,7 +154,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         );
     }
 
-    public function testItemsDoesNotTouchRangeIfNoCommitsWereFound()
+    public function testItemsDoesNotTouchRangeIfNoCommitsWereFound(): void
     {
         $faker = $this->faker();
 
@@ -201,7 +201,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         );
     }
 
-    public function testItemsDoesNotTouchRangeIfNoMergeCommitsWereFound()
+    public function testItemsDoesNotTouchRangeIfNoMergeCommitsWereFound(): void
     {
         $faker = $this->faker();
 
@@ -255,7 +255,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         );
     }
 
-    public function testItemsFetchesPullRequestIfMergeCommitWasFound()
+    public function testItemsFetchesPullRequestIfMergeCommitWasFound(): void
     {
         $faker = $this->faker();
 
@@ -332,7 +332,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         self::assertSame($mutatedRange, $actualRange);
     }
 
-    public function testItemsHandlesMergeCommitWherePullRequestWasNotFound()
+    public function testItemsHandlesMergeCommitWherePullRequestWasNotFound(): void
     {
         $faker = $this->faker();
 

--- a/test/Unit/Resource/CommitTest.php
+++ b/test/Unit/Resource/CommitTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -25,7 +25,7 @@ final class CommitTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testImplementsAuthorInterface()
+    public function testImplementsAuthorInterface(): void
     {
         $this->assertClassImplementsInterface(Resource\CommitInterface::class, Resource\Commit::class);
     }
@@ -35,7 +35,7 @@ final class CommitTest extends Framework\TestCase
      *
      * @param string $sha
      */
-    public function testConstructorRejectsInvalidSha(string $sha)
+    public function testConstructorRejectsInvalidSha(string $sha): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage(\sprintf(
@@ -51,7 +51,7 @@ final class CommitTest extends Framework\TestCase
         );
     }
 
-    public function testConstructorSetsShaAndMessage()
+    public function testConstructorSetsShaAndMessage(): void
     {
         $faker = $this->faker();
 
@@ -67,7 +67,7 @@ final class CommitTest extends Framework\TestCase
         self::assertSame($message, $commit->message());
     }
 
-    public function testEqualsReturnsFalseIfHashesAreDifferent()
+    public function testEqualsReturnsFalseIfHashesAreDifferent(): void
     {
         $faker = $this->faker();
 
@@ -84,7 +84,7 @@ final class CommitTest extends Framework\TestCase
         self::assertFalse($one->equals($two));
     }
 
-    public function testEqualsReturnsTrueIfHashesAreTheSame()
+    public function testEqualsReturnsTrueIfHashesAreTheSame(): void
     {
         $faker = $this->faker();
 

--- a/test/Unit/Resource/PullRequestTest.php
+++ b/test/Unit/Resource/PullRequestTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -25,7 +25,7 @@ final class PullRequestTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testImplementsPullRequestInterface()
+    public function testImplementsPullRequestInterface(): void
     {
         $this->assertClassImplementsInterface(Resource\PullRequestInterface::class, Resource\PullRequest::class);
     }
@@ -35,7 +35,7 @@ final class PullRequestTest extends Framework\TestCase
      *
      * @param mixed $number
      */
-    public function testConstructorRejectsInvalidNumber(int $number)
+    public function testConstructorRejectsInvalidNumber(int $number): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage(\sprintf(
@@ -55,7 +55,7 @@ final class PullRequestTest extends Framework\TestCase
         );
     }
 
-    public function testConstructorSetsValues()
+    public function testConstructorSetsValues(): void
     {
         $faker = $this->faker();
 

--- a/test/Unit/Resource/RangeTest.php
+++ b/test/Unit/Resource/RangeTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -24,12 +24,12 @@ final class RangeTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testImplementsRangeInterface()
+    public function testImplementsRangeInterface(): void
     {
         $this->assertClassImplementsInterface(Resource\RangeInterface::class, Resource\Range::class);
     }
 
-    public function testDefaults()
+    public function testDefaults(): void
     {
         $range = new Resource\Range();
 
@@ -37,7 +37,7 @@ final class RangeTest extends Framework\TestCase
         self::assertSame([], $range->pullRequests());
     }
 
-    public function testWithCommitClonesRangeAndAddsCommit()
+    public function testWithCommitClonesRangeAndAddsCommit(): void
     {
         $commit = $this->createCommitMock();
 
@@ -52,7 +52,7 @@ final class RangeTest extends Framework\TestCase
         self::assertContains($commit, $mutated->commits());
     }
 
-    public function testWithPullRequestClonesRangeAndAddsPullRequest()
+    public function testWithPullRequestClonesRangeAndAddsPullRequest(): void
     {
         $pullRequest = $this->createPullRequestMock();
 

--- a/test/Unit/Resource/RepositoryTest.php
+++ b/test/Unit/Resource/RepositoryTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -25,7 +25,7 @@ final class RepositoryTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testImplementsRepositoryInterface()
+    public function testImplementsRepositoryInterface(): void
     {
         $this->assertClassImplementsInterface(Resource\RepositoryInterface::class, Resource\Repository::class);
     }
@@ -35,7 +35,7 @@ final class RepositoryTest extends Framework\TestCase
      *
      * @param string $owner
      */
-    public function testFromOwnerAndNameRejectsInvalidOwner(string $owner)
+    public function testFromOwnerAndNameRejectsInvalidOwner(string $owner): void
     {
         $faker = $this->faker();
 
@@ -58,7 +58,7 @@ final class RepositoryTest extends Framework\TestCase
      *
      * @param string $name
      */
-    public function testFromOwnerAndNameRejectsInvalidName(string $name)
+    public function testFromOwnerAndNameRejectsInvalidName(string $name): void
     {
         $faker = $this->faker();
 
@@ -82,7 +82,7 @@ final class RepositoryTest extends Framework\TestCase
      * @param string $owner
      * @param string $name
      */
-    public function testFromOwnerAndNameReturnsRepository(string $owner, string $name)
+    public function testFromOwnerAndNameReturnsRepository(string $owner, string $name): void
     {
         $repository = Resource\Repository::fromOwnerAndName(
             $owner,
@@ -99,7 +99,7 @@ final class RepositoryTest extends Framework\TestCase
      *
      * @param string $remoteUrl
      */
-    public function testFromRemoteUrlRejectsInvalidRemoteUrl(string $remoteUrl)
+    public function testFromRemoteUrlRejectsInvalidRemoteUrl(string $remoteUrl): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage(\sprintf(\sprintf(
@@ -117,7 +117,7 @@ final class RepositoryTest extends Framework\TestCase
      * @param string $owner
      * @param string $name
      */
-    public function testFromRemoteUrlReturnsRepository(string $remoteUrl, string $owner, string $name)
+    public function testFromRemoteUrlReturnsRepository(string $remoteUrl, string $owner, string $name): void
     {
         $repository = Resource\Repository::fromRemoteUrl($remoteUrl);
 
@@ -126,7 +126,7 @@ final class RepositoryTest extends Framework\TestCase
         self::assertSame($name, $repository->name());
     }
 
-    public function testToStringReturnsStringRepresentation()
+    public function testToStringReturnsStringRepresentation(): void
     {
         $faker = $this->faker();
 
@@ -152,7 +152,7 @@ final class RepositoryTest extends Framework\TestCase
      *
      * @param string $string
      */
-    public function testFromStringRejectsInvalidStrings(string $string)
+    public function testFromStringRejectsInvalidStrings(string $string): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage(\sprintf(
@@ -169,7 +169,7 @@ final class RepositoryTest extends Framework\TestCase
      * @param string $owner
      * @param string $name
      */
-    public function testFromStringReturnsRepository(string $owner, string $name)
+    public function testFromStringReturnsRepository(string $owner, string $name): void
     {
         $string = \sprintf(
             '%s/%s',

--- a/test/Unit/Resource/UserTest.php
+++ b/test/Unit/Resource/UserTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -24,12 +24,12 @@ final class UserTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testImplementsAuthorInterface()
+    public function testImplementsAuthorInterface(): void
     {
         $this->assertClassImplementsInterface(Resource\UserInterface::class, Resource\User::class);
     }
 
-    public function testConstructorSetsLogin()
+    public function testConstructorSetsLogin(): void
     {
         $login = $this->faker()->slug();
 

--- a/test/Unit/Util/GitTest.php
+++ b/test/Unit/Util/GitTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -30,7 +30,7 @@ final class GitTest extends Framework\TestCase
      */
     private $remoteUrls = [];
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         if (!\count($this->remoteUrls)) {
             return;
@@ -50,12 +50,12 @@ final class GitTest extends Framework\TestCase
         $this->remoteUrls = null;
     }
 
-    public function testImplementsGitInterface()
+    public function testImplementsGitInterface(): void
     {
         $this->assertClassImplementsInterface(GitInterface::class, Git::class);
     }
 
-    public function testRemoteUrlsReturnsRemoteUrls()
+    public function testRemoteUrlsReturnsRemoteUrls(): void
     {
         \exec(
             'git remote',

--- a/test/Unit/Util/RepositoryResolverTest.php
+++ b/test/Unit/Util/RepositoryResolverTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -28,12 +28,12 @@ final class RepositoryResolverTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testImplementsRepositoryResolverInterface()
+    public function testImplementsRepositoryResolverInterface(): void
     {
         $this->assertClassImplementsInterface(RepositoryResolverInterface::class, RepositoryResolver::class);
     }
 
-    public function testResolveThrowsRuntimeExceptionIfUnableToDetermineRemoteUrls()
+    public function testResolveThrowsRuntimeExceptionIfUnableToDetermineRemoteUrls(): void
     {
         $git = $this->createGitMock();
 
@@ -50,7 +50,7 @@ final class RepositoryResolverTest extends Framework\TestCase
         $resolver->resolve();
     }
 
-    public function testResolveThrowsRuntimeExceptionIfNoRemoteUrlsHaveBeenFound()
+    public function testResolveThrowsRuntimeExceptionIfNoRemoteUrlsHaveBeenFound(): void
     {
         $remoteUrls = [];
 
@@ -74,7 +74,7 @@ final class RepositoryResolverTest extends Framework\TestCase
      *
      * @param string $remoteUrl
      */
-    public function testResolveThrowsRuntimeExceptionIfNoValidRemoteUrlsCouldBeFound(string $remoteUrl)
+    public function testResolveThrowsRuntimeExceptionIfNoValidRemoteUrlsCouldBeFound(string $remoteUrl): void
     {
         $faker = $this->faker();
 
@@ -104,7 +104,7 @@ final class RepositoryResolverTest extends Framework\TestCase
         $resolver->resolve();
     }
 
-    public function testResolveWithoutFromRemoteNamesReturnsRepositoryUsingFirstFoundValidRemoteUrl()
+    public function testResolveWithoutFromRemoteNamesReturnsRepositoryUsingFirstFoundValidRemoteUrl(): void
     {
         $faker = $this->faker();
 
@@ -144,7 +144,7 @@ final class RepositoryResolverTest extends Framework\TestCase
         self::assertSame($name, $repository->name());
     }
 
-    public function testResolveWithFromRemoteNamesThrowsRuntimeExceptionIfNoValidRemoteUrlsCanBeConsidered()
+    public function testResolveWithFromRemoteNamesThrowsRuntimeExceptionIfNoValidRemoteUrlsCanBeConsidered(): void
     {
         $faker = $this->faker();
 
@@ -183,7 +183,7 @@ final class RepositoryResolverTest extends Framework\TestCase
         $resolver->resolve(...$fromRemoteNames);
     }
 
-    public function testResolveWithFromRemoteNamesReturnsRepositoryUsingFirstFoundValidRemoteUrlIfItCanBeConsidered()
+    public function testResolveWithFromRemoteNamesReturnsRepositoryUsingFirstFoundValidRemoteUrlIfItCanBeConsidered(): void
     {
         $faker = $this->faker();
 

--- a/test/Util/DataProvider.php
+++ b/test/Util/DataProvider.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.


### PR DESCRIPTION
This PR

* [x] updates `localheinz/php-cs-fixer-config` 
* [x] runs `make cs`
* [x] does not remove `localheinz/php-cs-fixer-config` on PHP 7.3

💁‍♂️ For reference, see https://github.com/localheinz/php-cs-fixer-config/compare/1.17.0...1.19.0.