### PR TITLE
Enhancement: Require phpstan/phpstan-deprecation-rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "localheinz/php-cs-fixer-config": "~1.19.2",
         "localheinz/test-util": "~0.7.0",
         "phpstan/phpstan": "~0.11.5",
+        "phpstan/phpstan-deprecation-rules": "~0.11.0",
         "phpstan/phpstan-phpunit": "~0.11.0",
         "phpstan/phpstan-strict-rules": "~0.11.0",
         "phpunit/phpunit": "^7.5.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c991d812f9a44e0c7da6cda6ab6d31fc",
+    "content-hash": "a16279b91a72d210d80ae1955c3598f0",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -3571,6 +3571,52 @@
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "time": "2019-03-25T16:40:09+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-deprecation-rules",
+            "version": "0.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
+                "reference": "449fee6223220b337760abca4444801ddcc8b38d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/449fee6223220b337760abca4444801ddcc8b38d",
+                "reference": "449fee6223220b337760abca4444801ddcc8b38d",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.0",
+                "php": "~7.1",
+                "phpstan/phpstan": "^0.11"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^3.0.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "jakub-onderka/php-parallel-lint": "^1.0",
+                "phing/phing": "^2.16.0",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpunit/phpunit": "^7.0",
+                "slevomat/coding-standard": "^4.5.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
+            "time": "2018-12-05T18:04:16+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,5 @@
 includes:
+	- vendor/phpstan/phpstan-deprecation-rules/rules.neon
 	- vendor/phpstan/phpstan-phpunit/extension.neon
 	- vendor/phpstan/phpstan-strict-rules/rules.neon
 	- vendor/phpstan/phpstan/conf/config.level7.neon

--- a/test/Unit/Util/GitTest.php
+++ b/test/Unit/Util/GitTest.php
@@ -108,6 +108,11 @@ final class GitTest extends Framework\TestCase
 
         $git = new Git();
 
-        self::assertArraySubset($this->remoteUrls, $git->remoteUrls());
+        $remoteUrls = $git->remoteUrls();
+
+        foreach ($this->remoteUrls as $remoteName => $remoteUrl) {
+            self::assertArrayHasKey($remoteName, $remoteUrls);
+            self::assertSame($remoteUrl, $remoteUrls[$remoteName]);
+        }
     }
 }


### PR DESCRIPTION
This PR

* [x] requires `phpstan/phpstan-deprecation-rules`
* [ ] includes `rules.neon` from `phpstan/phpstan-deprecation-rules`
* [ ] fixes issues detected via static analysis