### PR TITLE
Fix: Add remote name to list of remote names and use in_array()

### DIFF
--- a/test/Unit/Util/GitTest.php
+++ b/test/Unit/Util/GitTest.php
@@ -72,7 +72,9 @@ final class GitTest extends Framework\TestCase
         while (3 > \count($this->remoteUrls)) {
             do {
                 $remoteName = $faker->unique()->word;
-            } while (\in_array($remoteName, \array_merge($remoteNames, $this->remoteUrls), true));
+            } while (\in_array($remoteName, $remoteNames, true));
+
+            $remoteNames[] = $remoteName;
 
             $owner = $faker->unique()->word;
             $name = $faker->unique()->word;


### PR DESCRIPTION
This PR

* [x] adds a remote name to the list of remote names and uses `in_array()` to avoid duplicates