### PR TITLE
Enhancement: Use phpspec/prophecy for test doubles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,7 @@ jobs:
         - xdebug-enable
 
       script:
-        - vendor/bin/infection --min-covered-msi=89 --min-msi=88
+        - vendor/bin/infection --min-covered-msi=88 --min-msi=87
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ cs: vendor
 	vendor/bin/php-cs-fixer fix --config=.php_cs --diff --verbose
 
 infection: vendor
-	vendor/bin/infection --min-covered-msi=89 --min-msi=88
+	vendor/bin/infection --min-covered-msi=88 --min-msi=87
 
 stan: vendor
 	mkdir -p .build/phpstan

--- a/test/Unit/Repository/CommitRepositoryTest.php
+++ b/test/Unit/Repository/CommitRepositoryTest.php
@@ -19,6 +19,7 @@ use Localheinz\GitHub\ChangeLog\Repository;
 use Localheinz\GitHub\ChangeLog\Resource;
 use Localheinz\Test\Util\Helper;
 use PHPUnit\Framework;
+use Prophecy\Argument;
 
 /**
  * @internal
@@ -49,21 +50,20 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $sha = $faker->sha1;
 
-        $commitApi = $this->createMock(Api\Repository\Commits::class);
+        $commitApi = $this->prophesize(Api\Repository\Commits::class);
 
         $expectedItem = $this->commitItem();
 
         $commitApi
-            ->expects(self::once())
-            ->method('show')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                self::identicalTo($sha)
+            ->show(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::is($sha)
             )
+            ->shouldBeCalled()
             ->willReturn($expectedItem);
 
-        $commitRepository = new Repository\CommitRepository($commitApi);
+        $commitRepository = new Repository\CommitRepository($commitApi->reveal());
 
         $commit = $commitRepository->show(
             $repository,
@@ -89,19 +89,18 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $sha = $faker->sha1;
 
-        $api = $this->createMock(Api\Repository\Commits::class);
+        $api = $this->prophesize(Api\Repository\Commits::class);
 
         $api
-            ->expects(self::once())
-            ->method('show')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                self::identicalTo($sha)
+            ->show(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::is($sha)
             )
+            ->shouldBeCalled()
             ->willReturn('failure');
 
-        $commitRepository = new Repository\CommitRepository($api);
+        $commitRepository = new Repository\CommitRepository($api->reveal());
 
         $this->expectException(Exception\ReferenceNotFound::class);
 
@@ -126,19 +125,18 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $sha = $faker->sha1;
 
-        $commitApi = $this->createMock(Api\Repository\Commits::class);
+        $commitApi = $this->prophesize(Api\Repository\Commits::class);
 
         $commitApi
-            ->expects(self::once())
-            ->method('all')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                $this->arrayHasKeyAndValue('sha', $sha)
+            ->all(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::withEntry('sha', $sha)
             )
+            ->shouldBeCalled()
             ->willReturn('snafu');
 
-        $commitRepository = new Repository\CommitRepository($commitApi);
+        $commitRepository = new Repository\CommitRepository($commitApi->reveal());
 
         $range = $commitRepository->all($repository, [
             'sha' => $sha,
@@ -164,21 +162,20 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $sha = $faker->sha1;
 
-        $commitApi = $this->createMock(Api\Repository\Commits::class);
+        $commitApi = $this->prophesize(Api\Repository\Commits::class);
 
         $expectedItems = $this->commitItems(15);
 
         $commitApi
-            ->expects(self::once())
-            ->method('all')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                $this->arrayHasKeyAndValue('per_page', 250)
+            ->all(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::withEntry('per_page', 250)
             )
+            ->shouldBeCalled()
             ->willReturn($this->reverse($expectedItems));
 
-        $commitRepository = new Repository\CommitRepository($commitApi);
+        $commitRepository = new Repository\CommitRepository($commitApi->reveal());
 
         $commitRepository->all($repository, [
             'sha' => $sha,
@@ -202,21 +199,20 @@ final class CommitRepositoryTest extends Framework\TestCase
         $sha = $faker->sha1;
         $perPage = $faker->numberBetween(1);
 
-        $commitApi = $this->createMock(Api\Repository\Commits::class);
+        $commitApi = $this->prophesize(Api\Repository\Commits::class);
 
         $expectedItems = $this->commitItems(15);
 
         $commitApi
-            ->expects(self::once())
-            ->method('all')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                $this->arrayHasKeyAndValue('per_page', $perPage)
+            ->all(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::withEntry('per_page', $perPage)
             )
+            ->shouldBeCalled()
             ->willReturn($this->reverse($expectedItems));
 
-        $commitRepository = new Repository\CommitRepository($commitApi);
+        $commitRepository = new Repository\CommitRepository($commitApi->reveal());
 
         $commitRepository->all($repository, [
             'sha' => $sha,
@@ -240,21 +236,20 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $sha = $faker->sha1;
 
-        $commitApi = $this->createMock(Api\Repository\Commits::class);
+        $commitApi = $this->prophesize(Api\Repository\Commits::class);
 
         $expectedItems = $this->commitItems(15);
 
         $commitApi
-            ->expects(self::once())
-            ->method('all')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                $this->arrayHasKeyAndValue('sha', $sha)
+            ->all(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::withEntry('sha', $sha)
             )
+            ->shouldBeCalled()
             ->willReturn($this->reverse($expectedItems));
 
-        $commitRepository = new Repository\CommitRepository($commitApi);
+        $commitRepository = new Repository\CommitRepository($commitApi->reveal());
 
         $range = $commitRepository->all($repository, [
             'sha' => $sha,
@@ -294,13 +289,7 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $endReference = $startReference;
 
-        $commitApi = $this->createMock(Api\Repository\Commits::class);
-
-        $commitApi
-            ->expects(self::never())
-            ->method(self::anything());
-
-        $commitRepository = new Repository\CommitRepository($commitApi);
+        $commitRepository = new Repository\CommitRepository($this->prophesize(Api\Repository\Commits::class)->reveal());
 
         $range = $commitRepository->items(
             $repository,
@@ -329,23 +318,22 @@ final class CommitRepositoryTest extends Framework\TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitApi = $this->createMock(Api\Repository\Commits::class);
+        $commitApi = $this->prophesize(Api\Repository\Commits::class);
 
         $commitApi
-            ->expects(self::at(0))
-            ->method('show')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                self::identicalTo($startReference)
+            ->show(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::is($startReference)
             )
+            ->shouldBeCalled()
             ->willReturn(null);
 
         $commitApi
-            ->expects(self::never())
-            ->method('all');
+            ->all()
+            ->shouldNotBeCalled();
 
-        $commitRepository = new Repository\CommitRepository($commitApi);
+        $commitRepository = new Repository\CommitRepository($commitApi->reveal());
 
         $range = $commitRepository->items(
             $repository,
@@ -375,33 +363,31 @@ final class CommitRepositoryTest extends Framework\TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitApi = $this->createMock(Api\Repository\Commits::class);
+        $commitApi = $this->prophesize(Api\Repository\Commits::class);
 
         $commitApi
-            ->expects(self::at(0))
-            ->method('show')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                self::identicalTo($startReference)
+            ->show(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::is($startReference)
             )
+            ->shouldBeCalled()
             ->willReturn($this->commitItem());
 
         $commitApi
-            ->expects(self::at(1))
-            ->method('show')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                self::identicalTo($endReference)
+            ->show(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::is($endReference)
             )
+            ->shouldBeCalled()
             ->willReturn(null);
 
         $commitApi
-            ->expects(self::never())
-            ->method('all');
+            ->all()
+            ->shouldNotBeCalled();
 
-        $commitRepository = new Repository\CommitRepository($commitApi);
+        $commitRepository = new Repository\CommitRepository($commitApi->reveal());
 
         $range = $commitRepository->items(
             $repository,
@@ -430,42 +416,39 @@ final class CommitRepositoryTest extends Framework\TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitApi = $this->createMock(Api\Repository\Commits::class);
+        $commitApi = $this->prophesize(Api\Repository\Commits::class);
 
         $startCommit = $this->commitItem();
 
         $commitApi
-            ->expects(self::at(0))
-            ->method('show')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                self::identicalTo($startReference)
+            ->show(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::is($startReference)
             )
+            ->shouldBeCalled()
             ->willReturn($startCommit);
 
         $endCommit = $this->commitItem();
 
         $commitApi
-            ->expects(self::at(1))
-            ->method('show')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                self::identicalTo($endReference)
+            ->show(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::is($endReference)
             )
+            ->shouldBeCalled()
             ->willReturn($endCommit);
 
         $commitApi
-            ->expects(self::once())
-            ->method('all')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                $this->arrayHasKeyAndValue('sha', $endCommit['sha'])
-            );
+            ->all(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::withEntry('sha', $endCommit['sha'])
+            )
+            ->shouldBeCalled();
 
-        $commitRepository = new Repository\CommitRepository($commitApi);
+        $commitRepository = new Repository\CommitRepository($commitApi->reveal());
 
         $commitRepository->items(
             $repository,
@@ -490,30 +473,28 @@ final class CommitRepositoryTest extends Framework\TestCase
 
         $startReference = $faker->sha1;
 
-        $commitApi = $this->createMock(Api\Repository\Commits::class);
+        $commitApi = $this->prophesize(Api\Repository\Commits::class);
 
         $startCommit = $this->commitItem();
 
         $commitApi
-            ->expects(self::once())
-            ->method('show')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                self::identicalTo($startReference)
+            ->show(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::is($startReference)
             )
+            ->shouldBeCalled()
             ->willReturn($startCommit);
 
         $commitApi
-            ->expects(self::once())
-            ->method('all')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                $this->arrayNotHasKey('sha')
-            );
+            ->all(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::not(Argument::withKey('sha'))
+            )
+            ->shouldBeCalled();
 
-        $commitRepository = new Repository\CommitRepository($commitApi);
+        $commitRepository = new Repository\CommitRepository($commitApi->reveal());
 
         $commitRepository->items(
             $repository,
@@ -538,30 +519,28 @@ final class CommitRepositoryTest extends Framework\TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitApi = $this->createMock(Api\Repository\Commits::class);
+        $commitApi = $this->prophesize(Api\Repository\Commits::class);
 
         $startCommit = $this->commitItem($faker->sha1);
 
         $commitApi
-            ->expects(self::at(0))
-            ->method('show')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                self::identicalTo($startReference)
+            ->show(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::is($startReference)
             )
+            ->shouldBeCalled()
             ->willReturn($startCommit);
 
         $endCommit = $this->commitItem($faker->sha1);
 
         $commitApi
-            ->expects(self::at(1))
-            ->method('show')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                self::identicalTo($endReference)
+            ->show(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::is($endReference)
             )
+            ->shouldBeCalled()
             ->willReturn($endCommit);
 
         $countBetween = 9;
@@ -585,16 +564,15 @@ final class CommitRepositoryTest extends Framework\TestCase
         );
 
         $commitApi
-            ->expects(self::once())
-            ->method('all')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                $this->arrayHasKeyAndValue('sha', $endCommit['sha'])
+            ->all(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::withEntry('sha', $endCommit['sha'])
             )
+            ->shouldBeCalled()
             ->willReturn($this->reverse($segment));
 
-        $commitRepository = new Repository\CommitRepository($commitApi);
+        $commitRepository = new Repository\CommitRepository($commitApi->reveal());
 
         $range = $commitRepository->items(
             $repository,
@@ -637,30 +615,28 @@ final class CommitRepositoryTest extends Framework\TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitApi = $this->createMock(Api\Repository\Commits::class);
+        $commitApi = $this->prophesize(Api\Repository\Commits::class);
 
         $startCommit = $this->commitItem($faker->sha1);
 
         $commitApi
-            ->expects(self::at(0))
-            ->method('show')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                self::identicalTo($startReference)
+            ->show(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::is($startReference)
             )
+            ->shouldBeCalled()
             ->willReturn($startCommit);
 
         $endCommit = $this->commitItem($faker->sha1);
 
         $commitApi
-            ->expects(self::at(1))
-            ->method('show')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                self::identicalTo($endReference)
+            ->show(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::is($endReference)
             )
+            ->shouldBeCalled()
             ->willReturn($endCommit);
 
         $countBetweenFirstSegment = 4;
@@ -698,26 +674,24 @@ final class CommitRepositoryTest extends Framework\TestCase
         );
 
         $commitApi
-            ->expects(self::at(2))
-            ->method('all')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                $this->arrayHasKeyAndValue('sha', $endCommit['sha'])
+            ->all(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::withEntry('sha', $endCommit['sha'])
             )
+            ->shouldBeCalled()
             ->willReturn($this->reverse($firstSegment));
 
         $commitApi
-            ->expects(self::at(3))
-            ->method('all')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                $this->arrayHasKeyAndValue('sha', $firstCommitFromFirstSegment['sha'])
+            ->all(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::withEntry('sha', $firstCommitFromFirstSegment['sha'])
             )
+            ->shouldBeCalled()
             ->willReturn($this->reverse($secondSegment));
 
-        $commitRepository = new Repository\CommitRepository($commitApi);
+        $commitRepository = new Repository\CommitRepository($commitApi->reveal());
 
         $range = $commitRepository->items(
             $repository,

--- a/test/Unit/Repository/PullRequestRepositoryTest.php
+++ b/test/Unit/Repository/PullRequestRepositoryTest.php
@@ -19,6 +19,7 @@ use Localheinz\GitHub\ChangeLog\Repository;
 use Localheinz\GitHub\ChangeLog\Resource;
 use Localheinz\Test\Util\Helper;
 use PHPUnit\Framework;
+use Prophecy\Argument;
 
 /**
  * @internal
@@ -48,23 +49,22 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             $faker->slug()
         );
 
-        $api = $this->createMock(Api\PullRequest::class);
+        $api = $this->prophesize(Api\PullRequest::class);
 
         $expectedItem = $this->pullRequestItem();
 
         $api
-            ->expects(self::once())
-            ->method('show')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                self::identicalTo((string) $expectedItem['number'])
+            ->show(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::is((string) $expectedItem['number'])
             )
+            ->shouldBeCalled()
             ->willReturn($expectedItem);
 
         $pullRequestRepository = new Repository\PullRequestRepository(
-            $api,
-            $this->createMock(Repository\CommitRepositoryInterface::class)
+            $api->reveal(),
+            $this->prophesize(Repository\CommitRepositoryInterface::class)->reveal()
         );
 
         $pullRequest = $pullRequestRepository->show(
@@ -92,21 +92,20 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             $faker->slug()
         );
 
-        $api = $this->createMock(Api\PullRequest::class);
+        $api = $this->prophesize(Api\PullRequest::class);
 
         $api
-            ->expects(self::once())
-            ->method('show')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                self::identicalTo((string) $number)
+            ->show(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::is((string) $number)
             )
+            ->shouldBeCalled()
             ->willReturn('snafu');
 
         $pullRequestRepository = new Repository\PullRequestRepository(
-            $api,
-            $this->createMock(Repository\CommitRepositoryInterface::class)
+            $api->reveal(),
+            $this->prophesize(Repository\CommitRepositoryInterface::class)->reveal()
         );
 
         $this->expectException(Exception\PullRequestNotFound::class);
@@ -136,28 +135,27 @@ final class PullRequestRepositoryTest extends Framework\TestCase
 
         $startReference = $faker->sha1;
 
-        $commitRepository = $this->createMock(Repository\CommitRepositoryInterface::class);
+        $commitRepository = $this->prophesize(Repository\CommitRepositoryInterface::class);
 
-        $range = $this->createMock(Resource\RangeInterface::class);
+        $range = $this->prophesize(Resource\RangeInterface::class);
 
         $range
-            ->expects(self::any())
-            ->method('commits')
+            ->commits()
+            ->shouldBeCalled()
             ->willReturn([]);
 
         $commitRepository
-            ->expects(self::once())
-            ->method('items')
-            ->with(
-                self::identicalTo($repository),
-                self::identicalTo($startReference),
-                self::identicalTo(null)
+            ->items(
+                Argument::is($repository),
+                Argument::is($startReference),
+                Argument::is(null)
             )
-            ->willReturn($range);
+            ->shouldBeCalled()
+            ->willReturn($range->reveal());
 
         $pullRequestRepository = new Repository\PullRequestRepository(
-            $this->createMock(Api\PullRequest::class),
-            $commitRepository
+            $this->prophesize(Api\PullRequest::class)->reveal(),
+            $commitRepository->reveal()
         );
 
         $pullRequestRepository->items(
@@ -181,32 +179,31 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $range = $this->createMock(Resource\RangeInterface::class);
+        $range = $this->prophesize(Resource\RangeInterface::class);
 
         $range
-            ->expects(self::any())
-            ->method('commits')
+            ->commits()
+            ->shouldBeCalled()
             ->willReturn([]);
 
         $range
-            ->expects(self::never())
-            ->method('withPullRequest');
+            ->withPullRequest()
+            ->shouldNotBeCalled();
 
-        $commitRepository = $this->createMock(Repository\CommitRepositoryInterface::class);
+        $commitRepository = $this->prophesize(Repository\CommitRepositoryInterface::class);
 
         $commitRepository
-            ->expects(self::once())
-            ->method('items')
-            ->with(
-                self::identicalTo($repository),
-                self::identicalTo($startReference),
-                self::identicalTo($endReference)
+            ->items(
+                Argument::is($repository),
+                Argument::is($startReference),
+                Argument::is($endReference)
             )
-            ->willReturn($range);
+            ->shouldBeCalled()
+            ->willReturn($range->reveal());
 
         $pullRequestRepository = new Repository\PullRequestRepository(
-            $this->createMock(Api\PullRequest::class),
-            $commitRepository
+            $this->prophesize(Api\PullRequest::class)->reveal(),
+            $commitRepository->reveal()
         );
 
         $pullRequestRepository->items(
@@ -232,39 +229,38 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitRepository = $this->createMock(Repository\CommitRepositoryInterface::class);
+        $commitRepository = $this->prophesize(Repository\CommitRepositoryInterface::class);
 
         $commit = new Resource\Commit(
             $faker->sha1,
             'I am not a merge commit'
         );
 
-        $range = $this->createMock(Resource\RangeInterface::class);
+        $range = $this->prophesize(Resource\RangeInterface::class);
 
         $range
-            ->expects(self::any())
-            ->method('commits')
+            ->commits()
+            ->shouldBeCalled()
             ->willReturn([
                 $commit,
             ]);
 
         $range
-            ->expects(self::never())
-            ->method('withPullRequest');
+            ->withPullRequest()
+            ->shouldNotBeCalled();
 
         $commitRepository
-            ->expects(self::once())
-            ->method('items')
-            ->with(
-                self::identicalTo($repository),
-                self::identicalTo($startReference),
-                self::identicalTo($endReference)
+            ->items(
+                Argument::is($repository),
+                Argument::is($startReference),
+                Argument::is($endReference)
             )
-            ->willReturn($range);
+            ->shouldBeCalled()
+            ->willReturn($range->reveal());
 
         $pullRequestRepository = new Repository\PullRequestRepository(
-            $this->createMock(Api\PullRequest::class),
-            $commitRepository
+            $this->prophesize(Api\PullRequest::class)->reveal(),
+            $commitRepository->reveal()
         );
 
         $pullRequestRepository->items(
@@ -292,7 +288,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitRepository = $this->createMock(Repository\CommitRepositoryInterface::class);
+        $commitRepository = $this->prophesize(Repository\CommitRepositoryInterface::class);
 
         $expectedItem = $this->pullRequestItem();
 
@@ -304,48 +300,45 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             )
         );
 
-        $mutatedRange = $this->createMock(Resource\RangeInterface::class);
+        $mutatedRange = $this->prophesize(Resource\RangeInterface::class);
 
-        $range = $this->createMock(Resource\RangeInterface::class);
+        $range = $this->prophesize(Resource\RangeInterface::class);
 
         $range
-            ->expects(self::any())
-            ->method('commits')
+            ->commits()
+            ->shouldBeCalled()
             ->willReturn([
                 $mergeCommit,
             ]);
 
         $range
-            ->expects(self::once())
-            ->method('withPullRequest')
-            ->with(self::isInstanceOf(Resource\PullRequestInterface::class))
-            ->willReturn($mutatedRange);
+            ->withPullRequest(Argument::type(Resource\PullRequestInterface::class))
+            ->shouldBeCalled()
+            ->willReturn($mutatedRange->reveal());
 
         $commitRepository
-            ->expects(self::once())
-            ->method('items')
-            ->with(
-                self::identicalTo($repository),
-                self::identicalTo($startReference),
-                self::identicalTo($endReference)
+            ->items(
+                Argument::is($repository),
+                Argument::is($startReference),
+                Argument::is($endReference)
             )
-            ->willReturn($range);
+            ->shouldBeCalled()
+            ->willReturn($range->reveal());
 
-        $api = $this->createMock(Api\PullRequest::class);
+        $api = $this->prophesize(Api\PullRequest::class);
 
         $api
-            ->expects(self::once())
-            ->method('show')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                self::identicalTo((string) $expectedItem['number'])
+            ->show(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::is((string) $expectedItem['number'])
             )
+            ->shouldBeCalled()
             ->willReturn($expectedItem);
 
         $pullRequestRepository = new Repository\PullRequestRepository(
-            $api,
-            $commitRepository
+            $api->reveal(),
+            $commitRepository->reveal()
         );
 
         $actualRange = $pullRequestRepository->items(
@@ -354,7 +347,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             $endReference
         );
 
-        self::assertSame($mutatedRange, $actualRange);
+        self::assertSame($mutatedRange->reveal(), $actualRange);
     }
 
     /**
@@ -375,7 +368,7 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         $startReference = $faker->sha1;
         $endReference = $faker->sha1;
 
-        $commitRepository = $this->createMock(Repository\CommitRepositoryInterface::class);
+        $commitRepository = $this->prophesize(Repository\CommitRepositoryInterface::class);
 
         $number = 9000;
 
@@ -387,44 +380,42 @@ final class PullRequestRepositoryTest extends Framework\TestCase
             )
         );
 
-        $range = $this->createMock(Resource\RangeInterface::class);
+        $range = $this->prophesize(Resource\RangeInterface::class);
 
         $range
-            ->expects(self::any())
-            ->method('commits')
+            ->commits()
+            ->shouldBeCalled()
             ->willReturn([
                 $mergeCommit,
             ]);
 
         $range
-            ->expects(self::never())
-            ->method('withPullRequest');
+            ->withPullRequest()
+            ->shouldNotBeCalled();
 
         $commitRepository
-            ->expects(self::once())
-            ->method('items')
-            ->with(
-                self::identicalTo($repository),
-                self::identicalTo($startReference),
-                self::identicalTo($endReference)
+            ->items(
+                Argument::is($repository),
+                Argument::is($startReference),
+                Argument::is($endReference)
             )
-            ->willReturn($range);
+            ->shouldBeCalled()
+            ->willReturn($range->reveal());
 
-        $pullRequestApi = $this->createMock(Api\PullRequest::class);
+        $pullRequestApi = $this->prophesize(Api\PullRequest::class);
 
         $pullRequestApi
-            ->expects(self::once())
-            ->method('show')
-            ->with(
-                self::identicalTo($repository->owner()),
-                self::identicalTo($repository->name()),
-                self::identicalTo((string) $number)
+            ->show(
+                Argument::is($repository->owner()),
+                Argument::is($repository->name()),
+                Argument::is((string) $number)
             )
+            ->shouldBeCalled()
             ->willReturn(null);
 
         $pullRequestRepository = new Repository\PullRequestRepository(
-            $pullRequestApi,
-            $commitRepository
+            $pullRequestApi->reveal(),
+            $commitRepository->reveal()
         );
 
         $pullRequestRepository->items(

--- a/test/Unit/Resource/RangeTest.php
+++ b/test/Unit/Resource/RangeTest.php
@@ -41,29 +41,29 @@ final class RangeTest extends Framework\TestCase
 
     public function testWithCommitClonesRangeAndAddsCommit(): void
     {
-        $commit = $this->createMock(Resource\CommitInterface::class);
+        $commit = $this->prophesize(Resource\CommitInterface::class);
 
         $range = new Resource\Range();
 
-        $mutated = $range->withCommit($commit);
+        $mutated = $range->withCommit($commit->reveal());
 
         self::assertNotSame($range, $mutated);
         self::assertCount(0, $range->commits());
         self::assertCount(1, $mutated->commits());
-        self::assertContains($commit, $mutated->commits());
+        self::assertContains($commit->reveal(), $mutated->commits());
     }
 
     public function testWithPullRequestClonesRangeAndAddsPullRequest(): void
     {
-        $pullRequest = $this->createMock(Resource\PullRequestInterface::class);
+        $pullRequest = $this->prophesize(Resource\PullRequestInterface::class);
 
         $range = new Resource\Range();
 
-        $mutated = $range->withPullRequest($pullRequest);
+        $mutated = $range->withPullRequest($pullRequest->reveal());
 
         self::assertNotSame($range, $mutated);
         self::assertCount(0, $range->pullRequests());
         self::assertCount(1, $mutated->pullRequests());
-        self::assertContains($pullRequest, $mutated->pullRequests());
+        self::assertContains($pullRequest->reveal(), $mutated->pullRequests());
     }
 }

--- a/test/Unit/Util/RepositoryResolverTest.php
+++ b/test/Unit/Util/RepositoryResolverTest.php
@@ -36,14 +36,14 @@ final class RepositoryResolverTest extends Framework\TestCase
 
     public function testResolveThrowsRuntimeExceptionIfUnableToDetermineRemoteUrls(): void
     {
-        $git = $this->createMock(GitInterface::class);
+        $git = $this->prophesize(GitInterface::class);
 
         $git
-            ->expects(self::once())
-            ->method('remoteUrls')
-            ->willThrowException(new Exception\RuntimeException());
+            ->remoteUrls()
+            ->shouldBeCalled()
+            ->willThrow(new Exception\RuntimeException());
 
-        $resolver = new RepositoryResolver($git);
+        $resolver = new RepositoryResolver($git->reveal());
 
         $this->expectException(Exception\RuntimeException::class);
         $this->expectExceptionMessage('Unable to resolve repository using git meta data.');
@@ -55,14 +55,14 @@ final class RepositoryResolverTest extends Framework\TestCase
     {
         $remoteUrls = [];
 
-        $git = $this->createMock(GitInterface::class);
+        $git = $this->prophesize(GitInterface::class);
 
         $git
-            ->expects(self::once())
-            ->method('remoteUrls')
+            ->remoteUrls()
+            ->shouldBeCalled()
             ->willReturn($remoteUrls);
 
-        $resolver = new RepositoryResolver($git);
+        $resolver = new RepositoryResolver($git->reveal());
 
         $this->expectException(Exception\RuntimeException::class);
         $this->expectExceptionMessage('Could not find any remote URLs.');
@@ -93,14 +93,14 @@ final class RepositoryResolverTest extends Framework\TestCase
             )
         );
 
-        $git = $this->createMock(GitInterface::class);
+        $git = $this->prophesize(GitInterface::class);
 
         $git
-            ->expects(self::once())
-            ->method('remoteUrls')
+            ->remoteUrls()
+            ->shouldBeCalled()
             ->willReturn($remoteUrls);
 
-        $resolver = new RepositoryResolver($git);
+        $resolver = new RepositoryResolver($git->reveal());
 
         $this->expectException(Exception\RuntimeException::class);
         $this->expectExceptionMessage('Could not find a valid remote URL.');
@@ -137,14 +137,14 @@ final class RepositoryResolverTest extends Framework\TestCase
 
         $remoteUrls[$remoteName] = $remoteUrl;
 
-        $git = $this->createMock(GitInterface::class);
+        $git = $this->prophesize(GitInterface::class);
 
         $git
-            ->expects(self::once())
-            ->method('remoteUrls')
+            ->remoteUrls()
+            ->shouldBeCalled()
             ->willReturn($remoteUrls);
 
-        $resolver = new RepositoryResolver($git);
+        $resolver = new RepositoryResolver($git->reveal());
 
         $repository = $resolver->resolve();
 
@@ -178,14 +178,14 @@ final class RepositoryResolverTest extends Framework\TestCase
         /** @var string[] $fromRemoteNames */
         $fromRemoteNames = $faker->unique()->words;
 
-        $git = $this->createMock(GitInterface::class);
+        $git = $this->prophesize(GitInterface::class);
 
         $git
-            ->expects(self::once())
-            ->method('remoteUrls')
+            ->remoteUrls()
+            ->shouldBeCalled()
             ->willReturn($remoteUrls);
 
-        $resolver = new RepositoryResolver($git);
+        $resolver = new RepositoryResolver($git->reveal());
 
         $this->expectException(Exception\RuntimeException::class);
         $this->expectExceptionMessage(\sprintf(
@@ -232,14 +232,14 @@ final class RepositoryResolverTest extends Framework\TestCase
 
         $remoteUrls[$remoteName] = $remoteUrl;
 
-        $git = $this->createMock(GitInterface::class);
+        $git = $this->prophesize(GitInterface::class);
 
         $git
-            ->expects(self::once())
-            ->method('remoteUrls')
+            ->remoteUrls()
+            ->shouldBeCalled()
             ->willReturn($remoteUrls);
 
-        $resolver = new RepositoryResolver($git);
+        $resolver = new RepositoryResolver($git->reveal());
 
         $repository = $resolver->resolve(...$fromRemoteNames);
 


### PR DESCRIPTION
This PR

* [x] uses `phpspec/prophecy` for generating test doubles