### PR TITLE
Enhancement: Store infection build files in .build/infection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /data/
 /vendor/
 .php_cs.cache
-/infection-log.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,6 +104,7 @@ jobs:
         - composer install
 
       before_script:
+        - mkdir -p .build/infection
         - xdebug-enable
 
       script:

--- a/infection.json
+++ b/infection.json
@@ -9,6 +9,6 @@
     "configDir": "test\/Unit"
   },
   "logs": {
-    "text": "infection-log.txt"
+    "text": ".build/infection/infection-log.txt"
   }
 }


### PR DESCRIPTION
This PR

* [x] stores infection build files in `.build/infection`