### PR TITLE
Fix: Explicitly list infection stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ stages:
   - style
   - stan
   - test
+  - infection
 
 jobs:
   include:


### PR DESCRIPTION
This PR

* [x] explicitly lists the `infection` stage