### PR TITLE
Fix: Add missing uses annotations

### DIFF
--- a/test/Unit/Console/GenerateCommandTest.php
+++ b/test/Unit/Console/GenerateCommandTest.php
@@ -131,6 +131,9 @@ final class GenerateCommandTest extends Framework\TestCase
         self::assertSame($default, $option->getDefault());
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testExecuteAuthenticatesIfTokenOptionIsGiven(): void
     {
         $authToken = $this->faker()->password();
@@ -174,6 +177,9 @@ final class GenerateCommandTest extends Framework\TestCase
         ]);
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testExecuteFailsIfRepositoryIsInvalid(): void
     {
         $repository = $this->repositoryFrom(
@@ -234,6 +240,9 @@ final class GenerateCommandTest extends Framework\TestCase
         self::assertContains($expectedMessage, $tester->getDisplay());
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testExecuteDelegatesToPullRequestRepositoryUsingRepositoryResolvedFromGitMetaData(): void
     {
         $faker = $this->faker();
@@ -293,6 +302,9 @@ final class GenerateCommandTest extends Framework\TestCase
         ]);
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testExecuteDelegatesToPullRequestRepositoryUsingRepositorySpecifiedInOptions(): void
     {
         $faker = $this->faker();
@@ -351,6 +363,9 @@ final class GenerateCommandTest extends Framework\TestCase
         ]);
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testExecuteRendersMessageIfNoPullRequestsWereFound(): void
     {
         $faker = $this->faker();
@@ -392,6 +407,9 @@ final class GenerateCommandTest extends Framework\TestCase
         self::assertRegExp('@' . $expectedMessage . '@', $tester->getDisplay());
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testExecuteRendersDifferentMessageIfNoPullRequestsWereFoundAndNoEndReferenceWasGiven(): void
     {
         $faker = $this->faker();
@@ -433,6 +451,11 @@ final class GenerateCommandTest extends Framework\TestCase
         self::assertContains($expectedMessage, $tester->getDisplay());
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\PullRequest
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\User
+     */
     public function testExecuteRendersPullRequestsWithTemplate(): void
     {
         $faker = $this->faker();
@@ -508,6 +531,11 @@ final class GenerateCommandTest extends Framework\TestCase
         }
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\PullRequest
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\User
+     */
     public function testExecuteRendersDifferentMessageWhenNoEndReferenceWasGiven(): void
     {
         $faker = $this->faker();
@@ -557,6 +585,9 @@ final class GenerateCommandTest extends Framework\TestCase
         self::assertContains($expectedMessage, $tester->getDisplay());
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testExecuteHandlesExceptionsThrownWhenFetchingPullRequests(): void
     {
         $faker = $this->faker();

--- a/test/Unit/Exception/PullRequestNotFoundTest.php
+++ b/test/Unit/Exception/PullRequestNotFoundTest.php
@@ -38,6 +38,9 @@ final class PullRequestNotFoundTest extends Framework\TestCase
         $this->assertClassImplementsInterface(ExceptionInterface::class, PullRequestNotFound::class);
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testFromRepositoryAndNumberCreatesException(): void
     {
         $faker = $this->faker();

--- a/test/Unit/Exception/ReferenceNotFoundTest.php
+++ b/test/Unit/Exception/ReferenceNotFoundTest.php
@@ -38,6 +38,9 @@ final class ReferenceNotFoundTest extends Framework\TestCase
         $this->assertClassImplementsInterface(ExceptionInterface::class, ReferenceNotFound::class);
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testFromRepositoryAndReferenceCreatesException(): void
     {
         $faker = $this->faker();

--- a/test/Unit/Repository/CommitRepositoryTest.php
+++ b/test/Unit/Repository/CommitRepositoryTest.php
@@ -34,6 +34,10 @@ final class CommitRepositoryTest extends Framework\TestCase
         $this->assertClassImplementsInterface(Repository\CommitRepositoryInterface::class, Repository\CommitRepository::class);
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testShowReturnsCommitEntityWithShaAndMessageOnSuccess(): void
     {
         $faker = $this->faker();
@@ -70,6 +74,10 @@ final class CommitRepositoryTest extends Framework\TestCase
         self::assertSame($expectedItem['commit']['message'], $commit->message());
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Exception\ReferenceNotFound
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testShowThrowsCommitNotFoundOnFailure(): void
     {
         $faker = $this->faker();
@@ -103,6 +111,10 @@ final class CommitRepositoryTest extends Framework\TestCase
         );
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testAllReturnsEmptyArrayOnFailure(): void
     {
         $faker = $this->faker();
@@ -136,6 +148,11 @@ final class CommitRepositoryTest extends Framework\TestCase
         self::assertCount(0, $range->commits());
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testAllSetsParamsPerPageTo250(): void
     {
         $faker = $this->faker();
@@ -168,6 +185,11 @@ final class CommitRepositoryTest extends Framework\TestCase
         ]);
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testAllStillAllowsSettingPerPage(): void
     {
         $faker = $this->faker();
@@ -202,6 +224,11 @@ final class CommitRepositoryTest extends Framework\TestCase
         ]);
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testAllReturnsRange(): void
     {
         $faker = $this->faker();
@@ -250,6 +277,10 @@ final class CommitRepositoryTest extends Framework\TestCase
         });
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testItemsDoesNotFetchCommitsIfStartAndEndReferencesAreTheSame(): void
     {
         $faker = $this->faker();
@@ -281,6 +312,11 @@ final class CommitRepositoryTest extends Framework\TestCase
         self::assertEmpty($range->pullRequests());
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Exception\ReferenceNotFound
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testItemsDoesNotFetchCommitsIfStartCommitCouldNotBeFound(): void
     {
         $faker = $this->faker();
@@ -321,6 +357,12 @@ final class CommitRepositoryTest extends Framework\TestCase
         self::assertEmpty($range->pullRequests());
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Exception\ReferenceNotFound
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testItemsDoesNotFetchCommitsIfEndCommitCouldNotBeFound(): void
     {
         $faker = $this->faker();
@@ -371,6 +413,11 @@ final class CommitRepositoryTest extends Framework\TestCase
         self::assertEmpty($range->pullRequests());
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testItemsFetchesCommitsUsingShaFromEndCommit(): void
     {
         $faker = $this->faker();
@@ -427,6 +474,11 @@ final class CommitRepositoryTest extends Framework\TestCase
         );
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testItemsFetchesCommitsIfEndReferenceIsNotGiven(): void
     {
         $faker = $this->faker();
@@ -469,6 +521,11 @@ final class CommitRepositoryTest extends Framework\TestCase
         );
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testItemsReturnsRangeOfCommitsFromEndToStartExcludingStart(): void
     {
         $faker = $this->faker();
@@ -563,6 +620,11 @@ final class CommitRepositoryTest extends Framework\TestCase
         });
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Range
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testItemsFetchesMoreCommitsIfEndIsNotContainedInFirstBatch(): void
     {
         $faker = $this->faker();

--- a/test/Unit/Repository/PullRequestRepositoryTest.php
+++ b/test/Unit/Repository/PullRequestRepositoryTest.php
@@ -34,6 +34,11 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         $this->assertClassImplementsInterface(Repository\PullRequestRepositoryInterface::class, Repository\PullRequestRepository::class);
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\PullRequest
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\User
+     */
     public function testShowReturnsPullRequestEntityWithNumberTitleAndAuthorOnSuccess(): void
     {
         $faker = $this->faker();
@@ -72,6 +77,10 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         self::assertSame($expectedItem['user']['login'], $pullRequest->author()->login());
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Exception\PullRequestNotFound
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testShowThrowsPullRequestNotFoundOnFailure(): void
     {
         $faker = $this->faker();
@@ -113,6 +122,9 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         );
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testItemsDoesNotRequireAnEndReference(): void
     {
         $faker = $this->faker();
@@ -154,6 +166,9 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         );
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testItemsDoesNotTouchRangeIfNoCommitsWereFound(): void
     {
         $faker = $this->faker();
@@ -201,6 +216,10 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         );
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testItemsDoesNotTouchRangeIfNoMergeCommitsWereFound(): void
     {
         $faker = $this->faker();
@@ -255,6 +274,12 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         );
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\PullRequest
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\User
+     */
     public function testItemsFetchesPullRequestIfMergeCommitWasFound(): void
     {
         $faker = $this->faker();
@@ -332,6 +357,12 @@ final class PullRequestRepositoryTest extends Framework\TestCase
         self::assertSame($mutatedRange, $actualRange);
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Exception\PullRequestNotFound
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Commit
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\PullRequest
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testItemsHandlesMergeCommitWherePullRequestWasNotFound(): void
     {
         $faker = $this->faker();

--- a/test/Unit/Resource/PullRequestTest.php
+++ b/test/Unit/Resource/PullRequestTest.php
@@ -33,6 +33,8 @@ final class PullRequestTest extends Framework\TestCase
     }
 
     /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\User
+     *
      * @dataProvider \Localheinz\GitHub\ChangeLog\Test\Util\DataProvider::providerInvalidPullRequestNumber
      *
      * @param int $number
@@ -57,6 +59,9 @@ final class PullRequestTest extends Framework\TestCase
         );
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\User
+     */
     public function testConstructorSetsValues(): void
     {
         $faker = $this->faker();

--- a/test/Unit/Util/RepositoryResolverTest.php
+++ b/test/Unit/Util/RepositoryResolverTest.php
@@ -71,6 +71,8 @@ final class RepositoryResolverTest extends Framework\TestCase
     }
 
     /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     *
      * @dataProvider \Localheinz\GitHub\ChangeLog\Test\Util\DataProvider::providerInvalidRemoteUrl
      *
      * @param string $remoteUrl
@@ -106,6 +108,9 @@ final class RepositoryResolverTest extends Framework\TestCase
         $resolver->resolve();
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testResolveWithoutFromRemoteNamesReturnsRepositoryUsingFirstFoundValidRemoteUrl(): void
     {
         $faker = $this->faker();
@@ -147,6 +152,9 @@ final class RepositoryResolverTest extends Framework\TestCase
         self::assertSame($name, $repository->name());
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testResolveWithFromRemoteNamesThrowsRuntimeExceptionIfNoValidRemoteUrlsCanBeConsidered(): void
     {
         $faker = $this->faker();
@@ -188,6 +196,9 @@ final class RepositoryResolverTest extends Framework\TestCase
         $resolver->resolve(...$fromRemoteNames);
     }
 
+    /**
+     * @uses \Localheinz\GitHub\ChangeLog\Resource\Repository
+     */
     public function testResolveWithFromRemoteNamesReturnsRepositoryUsingFirstFoundValidRemoteUrlIfItCanBeConsidered(): void
     {
         $faker = $this->faker();


### PR DESCRIPTION
This PR

* [x] adds missing `@uses` annotations

Follows #266.