### PR TITLE
Fix: Class name reference in covers annotation

### DIFF
--- a/test/Unit/Resource/RangeTest.php
+++ b/test/Unit/Resource/RangeTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework;
 /**
  * @internal
  *
- * @covers \Localheinz\GitHub\ChangeLog\Resource\Rangenge
+ * @covers \Localheinz\GitHub\ChangeLog\Resource\Range
  */
 final class RangeTest extends Framework\TestCase
 {


### PR DESCRIPTION
This PR

* [x] fixes a class name in `@covers` annotation

Follows #266.